### PR TITLE
Dynamic accessing of children in-line with how Form does it.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -43,4 +43,15 @@ class ChildFormType extends ParentType
 
         throw new \Exception('Please provide instance of Form class.');
     }
+
+    /**
+     * Get child dynamically
+     *
+     * @param $name
+     * @return FormField
+     */
+    public function __get($name)
+    {
+        return $this->getChild($name);
+    }
 }


### PR DESCRIPTION
Form has a magic getter to get the fields it contains, but a child form does not even though its technically meant to be the same kind of entity.
Added this to my local install as it makes things more consistent, pushing up here to see if you agree.