### PR TITLE
Readme suggestion causes exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,9 @@ class PostForm extends Form
     {
         $this
             ->add('name', 'text', [
-                'wrapper' => 'name-input-container',
+                'wrapper' => [
+                  'class' => 'name-input-container'
+                ],
                 'attr' => ['class' => 'input-name', 'placeholder' => 'Enter name here...'],
                 'label' => 'Full name'
             ])


### PR DESCRIPTION
Using a string inside the wrapper option causes an exception on line [171](https://github.com/kristijanhusak/laravel-form-builder/blob/laravel-4/src/Kris/LaravelFormBuilder/FormHelper.php#L171) on FormHelper due to it using an array and not a string.