### PR TITLE
Set data for child forms and create named forms.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -58,7 +58,6 @@ class ChildFormType extends ParentType
     protected function createChildren()
     {
         $this->rebuild();
-        $this->setValue($this->form->getDataArray(), true);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -59,6 +59,7 @@ class ChildFormType extends ParentType
     protected function createChildren()
     {
         $this->rebuild();
+        $this->setValue($this->form->getDataArray(), true);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -432,6 +432,16 @@ class Form
     }
 
     /**
+     * Get all data. ($this->data)
+     *
+     * @return mixed
+     */
+    public function getDataArray()
+    {
+        return $this->data;
+    }
+
+    /**
      * Add multiple peices of data at once
      *
      * @param $data

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -54,6 +54,37 @@ class FormBuilder
     }
 
     /**
+     * Create named form to group fields in this form by a name.
+     * Fields are named like name[field].
+     *
+     * @param $name
+     * @param $formClass
+     * @param array $options
+     * @param array $data
+     * @return Form
+     */
+    public function createNamedForm($name, $formClass, array $options = [], array $data = [])
+    {
+        $dataReal = $data;
+        if (empty($dataReal)) {
+            if (isset($options['model']) && is_object($options['model']) && method_exists($options['model'], 'toArray')) {
+                $dataReal = $options['model']->toArray();
+            }
+        }
+
+        return $this->plain(
+            $options
+        )->add(
+            $name,
+            'form',
+            [
+                'class' => $this->create($formClass, $options, $dataReal),
+                'label' => isset($options['label']) ? $options['label'] : false
+            ]
+        );
+    }
+
+    /**
      * Get the namespace from the config
      *
      * @return string

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -52,10 +52,15 @@ class FormBuilder
 
         // reset model to match named form logic
         if ($form->getName()) {
+            $modelData = [];
             if ($form->getModel() instanceof Model && method_exists($form->getModel(), 'toArray')) {
-                $form->setModel([$form->getName() => $form->getModel()->toArray()]);
+                $modelData = $form->getModel()->toArray();
             } elseif (is_array($form->getModel())) {
-                $form->setModel([$form->getName() => $form->getModel()]);
+                $modelData = $form->getModel();
+            }
+
+            if (!isset($modelData[$form->getName()])) {
+                $form->setModel([$form->getName() => $modelData]);
             }
         }
 


### PR DESCRIPTION
Not sure if this was bug or missing feature, but I was not able to pass data for child forms. Now its possible.
Also added new method in FormBuilder to create named forms like Symfony does. Form field names become like youname[fieldname].