### PR TITLE
Added form_until helper

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -195,23 +195,24 @@ class Form
     /**
      * Renders the rest of the form up until the specified field name
      *
-     * @param bool $showFormEnd
-     * @param bool $showFields
+     * @param string $field_name
+     * @param bool   $showFormEnd
+     * @param bool   $showFields
      * @return string
      */
     public function renderUntil($field_name, $showFormEnd = true, $showFields = true)
     {
         $fields = $this->getUnrenderedFields();
 
-		$i = 1;
-		foreach ($fields as $key => $value) {
-			if ($value->getName() == $field_name) {
-				break;
-			}
-			$i++;
-		}
+        $i = 1;
+        foreach ($fields as $key => $value) {
+            if ($value->getName() == $field_name) {
+                break;
+            }
+            $i++;
+        }
 
-		$fields = array_slice($fields, 0, $i, true);
+        $fields = array_slice($fields, 0, $i, true);
 
         return $this->render([], $fields, false, $showFields, $showFormEnd);
     }

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -193,6 +193,30 @@ class Form
     }
 
     /**
+     * Renders the rest of the form up until the specified field name
+     *
+     * @param bool $showFormEnd
+     * @param bool $showFields
+     * @return string
+     */
+    public function renderUntil($field_name, $showFormEnd = true, $showFields = true)
+    {
+        $fields = $this->getUnrenderedFields();
+
+		$i = 1;
+		foreach ($fields as $key => $value) {
+			if ($value->getName() == $field_name) {
+				break;
+			}
+			$i++;
+		}
+
+		$fields = array_slice($fields, 0, $i, true);
+
+        return $this->render([], $fields, false, $showFields, $showFormEnd);
+    }
+
+    /**
      * Get single field instance from form object
      *
      * @param $name

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -39,6 +39,15 @@ if (!function_exists('form_rest')) {
 
 }
 
+if (!function_exists('form_until')) {
+
+    function form_until(Form $form, $field_name)
+    {
+        return $form->renderUntil($field_name, false);
+    }
+
+}
+
 if (!function_exists('form_row')) {
 
     function form_row(FormField $formField, array $options = [])

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -288,11 +288,13 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm
             ->add('gender', 'select')
             ->add('name', 'text')
-            ->add('email', 'email');
+            ->add('email', 'email')
+            ->add('address', 'text');
 
         $this->plainForm->gender->render();
 
-        $this->plainForm->renderUntil('name');
+        $this->plainForm->renderUntil('email');
+        $this->assertEquals($this->plainForm->address->isRendered(), false);
     }
 
     /** @test */

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -266,6 +266,36 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_renders_rest_of_the_form_until_specified_field()
+    {
+        $options = [
+            'method' => 'GET',
+            'url' => '/some/url/10'
+        ];
+
+        $this->prepareFieldRender('select');
+        $this->prepareFieldRender('text');
+
+        $fields = [
+            new InputType('name', 'text', $this->plainForm),
+            new InputType('email', 'email', $this->plainForm),
+        ];
+
+        $this->prepareRender($options, false, true, true, $fields);
+
+        $this->plainForm->setFormOptions($options);
+
+        $this->plainForm
+            ->add('gender', 'select')
+            ->add('name', 'text')
+            ->add('email', 'email');
+
+        $this->plainForm->gender->render();
+
+        $this->plainForm->renderUntil('name');
+    }
+
+    /** @test */
     public function it_can_add_child_form_as_field()
     {
         $form = $this->setupForm(new Form());


### PR DESCRIPTION
Added form_until helper that renders all previously unrendered form fields up until and including the field name passed as the second argument.  E.g.:
```
{!! form_start($form) !!}
{!! form_until($form, 'field_name') !!}
<p>Some other html before continuing with the form...</p>
{!! form_end($form) !!}
```