### PR TITLE
Add ability to get all of $data from the form.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -152,7 +152,7 @@ class Form
      * @return Form
      */
     public function modify($name, $type = 'text', array $options = [], $overwriteOptions = false)
-    {
+    {g
         // If we don't want to overwrite options, we merge them with old options
         if ($overwriteOptions === false && $this->has($name)) {
             $options = $this->formHelper->mergeOptions(
@@ -480,9 +480,13 @@ class Form
      * @param null   $default
      * @return mixed
      */
-    public function getData($name, $default = null)
+    public function getData($name = null, $default = null)
     {
-        return array_get($this->data, $name, $default);
+        if( is_null($name) ) {
+            return $this->data;
+        } else {
+            return array_get($this->data, $name, $default);
+        }
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -152,7 +152,7 @@ class Form
      * @return Form
      */
     public function modify($name, $type = 'text', array $options = [], $overwriteOptions = false)
-    {g
+    {
         // If we don't want to overwrite options, we merge them with old options
         if ($overwriteOptions === false && $this->has($name)) {
             $options = $this->formHelper->mergeOptions(


### PR DESCRIPTION
I saw #55 after searching for issues and PR's to do with `getData()` but didnt seem to fit my issue as I dont use models with most of my forms.

What I'm looking for is flexibility to be able to get the the whole `$data` property of a form, rather than just 1 key which is all that is supported with the current `getData()` function.