### PR TITLE
Add ability to exclude fields from rendering.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -47,7 +47,8 @@ class ChildFormType extends ParentType
             'class' => null,
             'default_value' => null,
             'formOptions' => [],
-            'data' => []
+            'data' => [],
+            'exclude' => []
         ];
     }
 

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -61,6 +61,13 @@ class Form
     protected $formBuilder;
 
     /**
+     * List of fields to not render
+     *
+     * @var array
+     **/
+    protected $exclude = [];
+
+    /**
      * Build the form
      *
      * @return mixed
@@ -532,6 +539,7 @@ class Form
             ->with('formOptions', $formOptions)
             ->with('fields', $fields)
             ->with('model', $this->getModel())
+            ->with('exclude', $this->exclude)
             ->render();
     }
 
@@ -683,5 +691,18 @@ class Form
     public function getFormBuilder()
     {
         return $this->formBuilder;
+    }
+
+    /**
+     * undocumented function
+     *
+     * @return void
+     * @author 
+     **/
+    public function exclude(array $fields)
+    {
+        $this->exclude = array_merge($this->exclude, $fields);
+
+        return $this;
     }
 }

--- a/src/views/child_form.php
+++ b/src/views/child_form.php
@@ -10,7 +10,9 @@
 
     <?php if ($showField): ?>
         <?php foreach ((array)$options['children'] as $child): ?>
-            <?= $child->render() ?>
+            <?php if( ! in_array( $child->getRealName(), (array)$options['exclude']) ) { ?>
+                <?= $child->render() ?>
+            <?php } ?>
         <?php endforeach; ?>
     <?php endif; ?>
 

--- a/src/views/form.php
+++ b/src/views/form.php
@@ -8,7 +8,9 @@
 
 <?php if ($showFields): ?>
     <?php foreach ($fields as $field): ?>
-        <?= $field->render() ?>
+    	<?php if( ! in_array($field->getName(), $exclude) ) { ?>
+        	<?= $field->render() ?>
+		<?php } ?>
     <?php endforeach; ?>
 <?php endif; ?>
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -417,7 +417,8 @@ class FormTest extends FormBuilderTestCase
         $showFields = true,
         $showEnd = true,
         $fields = [],
-        $model = null
+        $model = null,
+        $exclude = []
     ) {
         $viewRenderer = Mockery::mock('Illuminate\Contracts\View\View');
 
@@ -443,6 +444,9 @@ class FormTest extends FormBuilderTestCase
                      ->andReturnSelf();
 
         $viewRenderer->shouldReceive('with')->with('model', $model)
+                     ->andReturnSelf();
+
+        $viewRenderer->shouldReceive('with')->with('exclude', $exclude)
                      ->andReturnSelf();
 
         $viewRenderer->shouldReceive('render');


### PR DESCRIPTION
Adds logic to `Form`, `ChildFormType` and respective views, to add the ability to mark fields to not render when calling `->renderForm()` or `->render()`.

When using with `Form`:
```
$form->exclude(['unwanted_field', 'another_field'])->renderForm();
```

When using with `ChildFormType`:
```
$form->child->render(
  ['exclude' => 
    ['unwanted_field', 'another_field']
  ]);
```

Not experienced with phpunit for testing so havnt included tests as when I tried to copy another test and tweak to fit this use-case, Mockery was throwing stuff at me that I dont know how to solve :P