### PR TITLE
update views to use correct name

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -105,6 +105,7 @@ abstract class FormField
             $this->template,
             [
                 'name' => $this->name,
+                'nameKey' => $this->getNameKey(),
                 'type' => $this->type,
                 'options' => $options,
                 'showLabel' => $showLabel,
@@ -195,6 +196,16 @@ abstract class FormField
         $this->name = $name;
 
         return $this;
+    }
+
+    /**
+     * Get dot notation key for fields
+     *
+     * @return string
+     **/
+    public function getNameKey()
+    {
+        return $this->transformKey($this->name);
     }
 
     /**
@@ -339,7 +350,7 @@ abstract class FormField
     {
         $errors = $this->formHelper->getRequest()->getSession()->get('errors');
 
-        if ($errors && $errors->has($this->name)) {
+        if ($errors && $errors->has($this->getNameKey())) {
             $errorClass = $this->formHelper->getConfig('defaults.wrapper_error_class');
 
             if ($options['wrapper'] && !str_contains($options['wrapper']['class'], $errorClass)) {

--- a/src/views/checkbox.php
+++ b/src/views/checkbox.php
@@ -17,7 +17,7 @@
     <?php endif; ?>
 
     <?php if ($showError && isset($errors)): ?>
-        <?php foreach ($errors->get(array_get($options, 'real_name', $name)) as $err): ?>
+        <?php foreach ($errors->get($nameKey) as $err): ?>
             <div <?= $options['errorAttrs'] ?>><?= $err ?></div>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/src/views/child_form.php
+++ b/src/views/child_form.php
@@ -17,7 +17,7 @@
     <?php endif; ?>
 
     <?php if ($showError && isset($errors)): ?>
-        <?php foreach ($errors->get(array_get($options, 'real_name', $name)) as $err): ?>
+        <?php foreach ($errors->get($nameKey) as $err): ?>
             <div <?= $options['errorAttrs'] ?>><?= $err ?></div>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/src/views/choice.php
+++ b/src/views/choice.php
@@ -15,7 +15,7 @@
     <?php endif; ?>
 
     <?php if ($showError && isset($errors)): ?>
-        <?php foreach ($errors->get(array_get($options, 'real_name', $name)) as $err): ?>
+        <?php foreach ($errors->get($nameKey) as $err): ?>
             <div <?= $options['errorAttrs'] ?>><?= $err ?></div>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/src/views/collection.php
+++ b/src/views/collection.php
@@ -15,7 +15,7 @@
     <?php endif; ?>
 
     <?php if ($showError && isset($errors)): ?>
-        <?php foreach ($errors->get(array_get($options, 'real_name', $name)) as $err): ?>
+        <?php foreach ($errors->get($nameKey) as $err): ?>
             <div <?= $options['errorAttrs'] ?>><?= $err ?></div>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/src/views/radio.php
+++ b/src/views/radio.php
@@ -17,7 +17,7 @@
     <?php endif; ?>
 
     <?php if ($showError && isset($errors)): ?>
-        <?php foreach ($errors->get(array_get($options, 'real_name', $name)) as $err): ?>
+        <?php foreach ($errors->get($nameKey) as $err): ?>
             <div <?= $options['errorAttrs'] ?>><?= $err ?></div>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/src/views/select.php
+++ b/src/views/select.php
@@ -15,7 +15,7 @@
 
 
     <?php if ($showError && isset($errors)): ?>
-        <?php foreach ($errors->get(array_get($options, 'real_name', $name)) as $err): ?>
+        <?php foreach ($errors->get($nameKey) as $err): ?>
             <div <?= $options['errorAttrs'] ?>><?= $err ?></div>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/src/views/text.php
+++ b/src/views/text.php
@@ -13,7 +13,7 @@
     <?php endif; ?>
 
     <?php if ($showError && isset($errors)): ?>
-        <?php foreach ($errors->get(array_get($options, 'real_name', $name)) as $err): ?>
+        <?php foreach ($errors->get($nameKey) as $err): ?>
             <div <?= $options['errorAttrs'] ?>><?= $err ?></div>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/src/views/textarea.php
+++ b/src/views/textarea.php
@@ -13,7 +13,7 @@
     <?php endif; ?>
 
     <?php if ($showError && isset($errors)): ?>
-        <?php foreach ($errors->get(array_get($options, 'real_name', $name)) as $err): ?>
+        <?php foreach ($errors->get($nameKey) as $err): ?>
             <div <?= $options['errorAttrs'] ?>><?= $err ?></div>
         <?php endforeach; ?>
     <?php endif; ?>

--- a/tests/Fields/ButtonTypeTest.php
+++ b/tests/Fields/ButtonTypeTest.php
@@ -21,6 +21,7 @@ class ButtonTypeTest extends FormBuilderTestCase
 
         $expectedViewData = [
             'name' => 'some_button',
+            'nameKey' => 'some_button',
             'type' => 'button',
             'options' => $expectedOptions,
             'showLabel' => true,
@@ -75,6 +76,7 @@ class ButtonTypeTest extends FormBuilderTestCase
 
         $expectedViewData = [
             'name' => 'some_submit',
+            'nameKey' => 'some_submit',
             'type' => 'submit',
             'options' => $expectedOptions,
             'showLabel' => true,

--- a/tests/Fields/InputTypeTest.php
+++ b/tests/Fields/InputTypeTest.php
@@ -22,6 +22,7 @@ class InputTypeTest extends FormBuilderTestCase
 
         $expectedViewData = [
             'name' => 'hidden_id',
+            'nameKey' => 'hidden_id',
             'type' => 'hidden',
             'options' => $expectedOptions,
             'showLabel' => false,

--- a/tests/Fields/StaticTypeTest.php
+++ b/tests/Fields/StaticTypeTest.php
@@ -33,6 +33,7 @@ class StaticTypeTest extends FormBuilderTestCase
 
         $expectedViewData = [
             'name' => 'some_static',
+            'nameKey' => 'some_static',
             'type' => 'static',
             'options' => $expectedOptions,
             'showLabel' => true,


### PR DESCRIPTION
Fixes #78 
Replaced all the 
```
array_get($options, 'real_name', $name)
```
with
```
$name
```
for grabbing errors from Laravels error bag.

Multiple Choice doesnt work with this method though, for a field with a "true" name of `form_name[field_name]` the `$name` in the view becomes `form_name[field_name][]` for HTML multiple choice to work obviously.

So at the moment multiple choice fields wont display error messages.

This is a short fix imo, I feel the design could use having views work off a `$htmlName` or whatever which can be manipulated. So `$name` can be always consistent with domain logic.

P.S. Fields edited but not used personally (so dont know how it effects):
- Collection
- Radio (though simple enough should be fine)
