### PR TITLE
Fix default value bug

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -95,7 +95,7 @@ abstract class FormField
             $this->valueClosure = $defaultValue;
         }
 
-        if ((!$defaultValue || $defaultValue instanceof \Closure) && !$isChild) {
+        if (($defaultValue === false || $defaultValue === null || $defaultValue instanceof \Closure) && !$isChild) {
             $this->setValue($this->getModelValueAttribute($this->parent->getModel(), $name));
         } elseif (!$isChild) {
             $this->hasDefault = true;


### PR DESCRIPTION
`! $defaultValue` isnt secure enough and causes type issues for example attempting to set a string of `"0"` evaluates as no default value.

The value of `$defaultValue` when no option is passed, is `false` so just make a hard check for that because nobody should try and set the `default_value` option as "no default value" because that's the default.