### PR TITLE
Add form composition

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -50,9 +50,7 @@ class ChildFormType extends ParentType
         if ($this->form->getFormOption('files')) {
             $this->parent->setFormOption('files', true);
         }
-
         $model = $this->getOption('default_value');
-
         if ($model !== false) {
             foreach ($this->form->getFields() as $name => $field) {
                 $field->setValue($this->getModelValueAttribute($model, $name));

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -233,13 +233,16 @@ class Form
             $fields = $class->getForm()->getFields();
         } elseif (is_string($class)) {
             // If its a string of a class make it the usual way
-            $childForm = $this->makeField('', 'form', $options);
-            if (! $childForm instanceof Fields\ChildFormType) {
-                throw new \InvalidArgumentException("Field [{$name}] is not a child form");
+            $options['model'] = $this->model;
+            $options['name'] = $this->name;
+
+            $form = $this->formBuilder->create($class, $options);
+            if (! $form instanceof Form) {
+                throw new \InvalidArgumentException("[{$name}] is not a form");
             }
-            $fields = $childForm->getForm()->getFields();
+            $fields = $form->getFields();
         } else {
-            throw new \InvalidArgumentException("\$class is invalid. Please provide either a string, Form or ChildFormType");
+            throw new \InvalidArgumentException("[{$class}] is invalid. Please provide either a string, Form or ChildFormType");
         }
         foreach ($fields as $field) {
             $this->addField($field);

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -104,9 +104,28 @@ class Form
 
         return $this;
     }
+    
+    /**
+     * Create the FormField object
+     *
+     * @param string $name
+     * @param string $type
+     * @param array  $options
+     * @return $this
+     */
+    public function makeField($name, $type = 'text', array $options = [])
+    {
+        $this->setupFieldOptions($name, $options);
+
+        $fieldName = $this->getFieldName($name);
+
+        $fieldType = $this->getFieldType($type);
+
+        return new $fieldType($fieldName, $type, $this, $options);
+    }
 
     /**
-     * Add a single field to the form
+     * Create a new field and add it to the form
      *
      * @param string $name
      * @param string $type
@@ -121,24 +140,28 @@ class Form
                 'Please provide valid field name for class ['. get_class($this) .']'
             );
         }
-
-        if (!$modify && !$this->rebuilding) {
-            $this->preventDuplicate($name);
-        }
-
+        
         if ($this->rebuilding && !$this->has($name)) {
             return $this;
         }
 
-        $this->setupFieldOptions($name, $options);
-
-        $fieldName = $this->getFieldName($name);
-
-        $fieldType = $this->getFieldType($type);
-
-        $this->fields[$name] = new $fieldType($fieldName, $type, $this, $options);
-
+        $this->addField($this->makeField($name, $type, $options), $modify);
+        
         return $this;
+    }
+
+    /**
+     * Add a FormField to the form's fields
+     *
+     * @param FormField $field
+     * @return $this
+     */
+    public function addField(FormField $field, $modify = false)
+    {
+        if (!$modify && !$this->rebuilding) {
+            $this->preventDuplicate($field->getRealName());
+        }
+        $this->fields[$field->getRealName()] = $field;
     }
 
     /**
@@ -169,7 +192,6 @@ class Form
 
     /**
      * Add field before another field
-
      * @param string  $name         Name of the field after which new field is added
      * @param string  $fieldName    Field name which will be added
      * @param string  $type
@@ -190,6 +212,38 @@ class Form
 
         $this->fields += $afterFields;
 
+        return $this;
+    }
+    
+    /**
+     * Take another form and add it's fields directly to this form
+     * @param mixed   $class        Form to merge
+     * @param array   $options
+     * @param boolean $modify
+     * @return $this
+     */
+    public function compose($class, array $options = [], $modify = false)
+    {
+        $options['class'] = $class;
+
+        // If we pass a ready made form just extract the fields
+        if ($class instanceof Form) {
+            $fields = $class->getFields();
+        } elseif ($class instanceof Fields\ChildFormType) {
+            $fields = $class->getForm()->getFields();
+        } elseif (is_string($class)) {
+            // If its a string of a class make it the usual way
+            $childForm = $this->makeField('', 'form', $options);
+            if (! $childForm instanceof Fields\ChildFormType) {
+                throw new \InvalidArgumentException("Field [{$name}] is not a child form");
+            }
+            $fields = $childForm->getForm()->getFields();
+        } else {
+            throw new \InvalidArgumentException("\$class is invalid. Please provide either a string, Form or ChildFormType");
+        }
+        foreach ($fields as $field) {
+            $this->addField($field);
+        }
         return $this;
     }
 
@@ -273,7 +327,7 @@ class Form
 
         $i = 1;
         foreach ($fields as $key => $value) {
-            if ($value->getName() == $field_name) {
+            if ($value->getRealName() == $field_name) {
                 break;
             }
             $i++;

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -503,6 +503,28 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->addCustomField('datetime', 'Some\\Namespace\\DateType');
     }
 
+
+    /** @test */
+    public function it_can_compose_another_forms_fields_into_itself()
+    {
+        $form = $this->setupForm(new Form());
+        $customForm = $this->setupForm(new CustomDummyForm());
+
+
+        $form
+            ->add('name', 'text')
+            ->compose($customForm)
+        ;
+
+        $this->assertEquals($form, $form->name->getParent());
+
+        $this->assertEquals(3, count($form->getFields()));
+        $this->assertEquals(true, $form->has('title'));
+        $this->assertEquals('title', $form->title->getName());
+        $this->assertEquals('title', $form->title->getRealName());
+
+    }
+
     private function prepareRender(
         $formOptions = [],
         $showStart = true,


### PR DESCRIPTION
This PR adds the ability to take a child form and add its fields directly to the parent form.

Added `makeField()` as an abstracted method of generating the `FormField`
Added `compose` which is used the same way as `add()` just only needing `$options` and the `$modify` flag. It creates the child form as usual via the new `makeField()` function, then just adds all the fields from that child form, to the parent form.

I've thrown this together as it fixed my issue of trying to use child forms to help with composition of forms but it messed up using model binding, and this is the best solution anyway I just hadnt thought of it till now :P