### PR TITLE
Proper handling of default values and new explicit value setting

### DIFF
--- a/src/views/checkbox.php
+++ b/src/views/checkbox.php
@@ -5,7 +5,7 @@
 <?php endif; ?>
 
     <?php if ($showField): ?>
-        <?= Form::checkbox($name, $options['default_value'], $options['checked'], $options['attr']) ?>
+        <?= Form::checkbox($name, $options['value'], $options['checked'], $options['attr']) ?>
 
         <?php if ($options['help_block']['text']): ?>
             <<?= $options['help_block']['tag'] ?> <?= $options['help_block']['helpBlockAttrs'] ?>>

--- a/src/views/radio.php
+++ b/src/views/radio.php
@@ -5,7 +5,7 @@
 <?php endif; ?>
 
     <?php if ($showField): ?>
-        <?= Form::radio($name, $options['default_value'], $options['checked'], $options['attr']) ?>
+        <?= Form::radio($name, $options['value'], $options['checked'], $options['attr']) ?>
 
         <?php if ($options['help_block']['text']): ?>
             <<?= $options['help_block']['tag'] ?> <?= $options['help_block']['helpBlockAttrs'] ?>>

--- a/src/views/static.php
+++ b/src/views/static.php
@@ -9,7 +9,7 @@
     <?php endif; ?>
 
     <?php if ($showField): ?>
-        <<?= $options['tag'] ?> <?= $options['elemAttrs'] ?>><?= $options['default_value'] ?></<?= $options['tag'] ?>>
+        <<?= $options['tag'] ?> <?= $options['elemAttrs'] ?>><?= $options['value'] ?></<?= $options['tag'] ?>>
 
         <?php if ($options['help_block']['text']): ?>
             <<?= $options['help_block']['tag'] ?> <?= $options['help_block']['helpBlockAttrs'] ?>>

--- a/src/views/text.php
+++ b/src/views/text.php
@@ -9,7 +9,7 @@
     <?php endif; ?>
 
     <?php if ($showField): ?>
-        <?= Form::input($type, $name, $options['default_value'], $options['attr']) ?>
+        <?= Form::input($type, $name, $options['value'], $options['attr']) ?>
 
         <?php if ($options['help_block']['text']): ?>
             <<?= $options['help_block']['tag'] ?> <?= $options['help_block']['helpBlockAttrs'] ?>>

--- a/src/views/textarea.php
+++ b/src/views/textarea.php
@@ -9,7 +9,7 @@
     <?php endif; ?>
 
     <?php if ($showField): ?>
-        <?= Form::textarea($name, $options['default_value'], $options['attr']) ?>
+        <?= Form::textarea($name, $options['value'], $options['attr']) ?>
 
         <?php if ($options['help_block']['text']): ?>
             <<?= $options['help_block']['tag'] ?> <?= $options['help_block']['helpBlockAttrs'] ?>>

--- a/tests/Fields/InputTypeTest.php
+++ b/tests/Fields/InputTypeTest.php
@@ -45,4 +45,30 @@ class InputTypeTest extends FormBuilderTestCase
 
         $hidden->render(['default_value' => 13]);
     }
+
+    /** @test */
+    public function it_handles_default_values()
+    {
+        $options = [
+            'default_value' => 100
+        ];
+        $this->plainForm->setModel(null);
+        $input = new InputType('test', 'text', $this->plainForm, $options);
+
+        $this->assertEquals(100, $input->getOption('value'));
+    }
+
+    /** @test */
+    public function explicit_value_overrides_default_values()
+    {
+        $options = [
+            'default_value' => 100,
+            'value' => 500
+        ];
+
+        $input = new InputType('test', 'text', $this->plainForm, $options);
+
+        $this->assertEquals(500, $input->getOption('value'));
+    }
+
 }

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -107,6 +107,7 @@ abstract class FormBuilderTestCase extends PHPUnit_Framework_TestCase {
                 'class' => 'help-block'
             ]],
             'default_value' => $defaultValue,
+            'value' => null,
             'label' => $label,
             'is_child' => false,
             'label_attr' => ['class' => 'control-label', 'for' => $id],


### PR DESCRIPTION
Right sorted after cleaning up some git mess.

TODO:
This breaks the test `it_can_add_child_form_as_field`, related to something with the collection type not child forms as child forms still work as expected.
I've never even looked at the collection stuff before so left it for now as I have zero experience with them.

To review:
`setValue()` I updated the closure to pass the parent's model along with it as it's helpful when dealing with complicated value resolving.
I wanted to double check with you why you pass an empty array to the closure instead of just null? Same for the `Form`'s `$model` default is an empty array. imo it should be null.

#### Changes introduced

Changes behaviour of the setting `'default_value'` and adds the setting `'value'`.
`'default_value'` is now treated as just a fallback value if no value can be found by other means. It also is overridden by a model value in any case, so if the model value is `null` then the field value will be set to `null`. I made this change as I believe if you're passing a model to a form, you're using the form to edit existing data and thus all values would already be set and `'default_value'` should only be used on a blank form for creating new models.

`'value'` setting explicitly sets the value of a field, overriding `'default_value'` AND any attached model.

`'value'` is now the container for whatever value the field needs to be filled with. previously it all just ran off `'default_value'` so all views where applicable have been updated (special note that this will need to be pointed out in changelog as will bork up peoples installations if they've published the views of the package). So anything that modifies / updates a form field value should interact with `'value'` and ignore `'default_value'`

Added `$modelValue` property to `FormField`, just an easy convenient way of storing the model value for that field. Now a field object will have a default value, explicit value and model value available at all times to reference. Part of the trouble before hand was the value logic was pretty much all down to the one little if block, and shoved the resolution back into `'default_value'`. Just adding more flexibility again.


I also added a couple tests to cover this functionality, I havnt added any related to model stuff as the use of global functions borks testing.

I think that pretty much covers it, any questions let me know, and give me some feedback re: the collection stuff seemingly breaking when you get the chance and I'll make whatever changes needed.