### PR TITLE
Tweak label formatting for greater flexibility

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -239,6 +239,6 @@ class FormHelper
             return null;
         }
 
-        return ucwords(str_replace('_', ' ', $name));
+        return ucfirst(str_replace('_', ' ', $name));
     }
 }

--- a/tests/Fields/ButtonTypeTest.php
+++ b/tests/Fields/ButtonTypeTest.php
@@ -17,7 +17,7 @@ class ButtonTypeTest extends FormBuilderTestCase
         $expectedOptions = $this->getDefaults(
             ['class' => 'btn-class', 'type' => 'button', 'disabled' => 'disabled'],
             'some_button',
-            'Some Button'
+            'Some button'
         );
 
         $expectedViewData = [
@@ -77,7 +77,7 @@ class ButtonTypeTest extends FormBuilderTestCase
         $expectedOptions = $this->getDefaults(
             ['type' => 'submit'],
             'some_submit',
-            'Some Submit'
+            'Some submit'
         );
 
         $expectedOptions['wrapper'] = false;

--- a/tests/Fields/InputTypeTest.php
+++ b/tests/Fields/InputTypeTest.php
@@ -20,9 +20,9 @@ class InputTypeTest extends FormBuilderTestCase
         $expectedOptions = $this->getDefaults(
             ['required' => 'required'],
             'hidden_id',
-            'Hidden Id',
+            'Hidden id',
             13,
-            'This is help'
+            'this is help'
         );
 
         $expectedOptions['help_block']['helpBlockAttrs'] = 'class="help-block" ';

--- a/tests/Fields/InputTypeTest.php
+++ b/tests/Fields/InputTypeTest.php
@@ -22,7 +22,7 @@ class InputTypeTest extends FormBuilderTestCase
             'hidden_id',
             'Hidden Id',
             13,
-            'this is help'
+            'This is help'
         );
 
         $expectedOptions['help_block']['helpBlockAttrs'] = 'class="help-block" ';

--- a/tests/Fields/StaticTypeTest.php
+++ b/tests/Fields/StaticTypeTest.php
@@ -18,7 +18,7 @@ class StaticTypeTest extends FormBuilderTestCase
         $expectedOptions = $this->getDefaults(
             ['class' => 'static-class', 'id' => 'some_static'],
             'some_static',
-            'Some Static',
+            'Some static',
             'static text'
         );
 

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -111,7 +111,7 @@ class FormHelperTest extends FormBuilderTestCase
     public function it_formats_the_label()
     {
         $this->assertEquals(
-            'Some Name',
+            'Some name',
             $this->formHelper->formatLabel('some_name')
         );
 


### PR DESCRIPTION
Hi @kristijanhusak 

Just started formatting all the forms on an app where I'm using the form builder and just noticed (for the first time!) that all labels are converted to title case which isn't really the most flexible output IMO.  Would be better to output as sentence case and if the user want to they can use CSS to convert to title case if required.  Switching to sentence case is likely to output a closer representation of what the author has written for the label in most cases