### PR TITLE
Process closure default values correctly

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -100,7 +100,13 @@ abstract class FormField
     protected function setupValue()
     {
         $value = $this->getOption($this->valueProperty);
+        $default = $this->getOption($this->defaultValueProperty);
         $isChild = $this->getOption('is_child');
+
+        if (is_null($value)) {
+            $value = $default;
+            $this->setOption($this->valueProperty, $default);
+        }
 
         if ($value instanceof \Closure) {
             $this->valueClosure = $value;


### PR DESCRIPTION
Started getting a wierd bug where closure default values in options were throwing errors on render because escaping strings was just interpreting them as objects because they were unresolved closures.

The root was some missing logic when the closures were actually processed, basically ignoring default values at that point.

This fixes it anyway.