### PR TITLE
Remove regex rule

### DIFF
--- a/src/Kris/LaravelFormBuilder/RulesParser.php
+++ b/src/Kris/LaravelFormBuilder/RulesParser.php
@@ -468,26 +468,6 @@ class RulesParser
     }
 
     /**
-     * Add a pattern attribute, based on the regex validation.
-     *
-     * This strips the delimiters:
-     *  regex:/^\d+$/  --> pattern="^\d+$"
-     *
-     * @param $param
-     * @return array
-     *
-     * @see http://laravel.com/docs/5.1/validation#rule-regex
-     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-pattern
-     */
-    protected function regex($param)
-    {
-        // Remove delimiters
-        $pattern = substr($param[0], 1, -1);
-
-        return ['pattern' => $pattern];
-    }
-
-    /**
      * Get the title, used for validating a rule
      *
      * @param  string $rule


### PR DESCRIPTION
I know I added this myself, but I don't feel really confident about this. Regexes are difficult and I don't think we can simply transform php regex to html patterns. It might give okay results for easy cases, but unpredictable for other cases. Best to just let the developer set his own pattern if he needs this.