### PR TITLE
Make it possible to resolve the entity option with the IoC

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/EntityType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/EntityType.php
@@ -50,7 +50,7 @@ class EntityType extends ChoiceType
                 $data = $data->lists($value, $key);
             }
         } else {
-            $data = [];
+            $data = $class->lists($value, $key);;
         }
 
         if ($data instanceof Collection) {

--- a/src/Kris/LaravelFormBuilder/Fields/EntityType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/EntityType.php
@@ -29,12 +29,12 @@ class EntityType extends ChoiceType
             return parent::createChildren();
         }
 
-        $entity = $this->getOption('class');
+        $class = $this->getOption('class');
         $queryBuilder = $this->getOption('query_builder');
         $key = $this->getOption('property_key');
         $value = $this->getOption('property');
 
-        if (!$entity || !class_exists($entity)) {
+        if (!$class || !class_exists($class)) {
             throw new \InvalidArgumentException(sprintf(
                 'Please provide valid "class" option for entity field [%s] in form class [%s]',
                 $this->getRealName(),
@@ -42,15 +42,17 @@ class EntityType extends ChoiceType
             ));
         }
 
-        $entity = new $entity();
+        $class = app($class);
 
         if ($queryBuilder instanceof \Closure) {
-            $data = $queryBuilder($entity);
+            $data = $queryBuilder($class);
             if (is_object($data) && method_exists($data, 'lists')) {
                 $data = $data->lists($value, $key);
             }
+        } elseif ($class instanceof Collection) {
+            $data = $class->lists($value, $key);
         } else {
-            $data = $entity->lists($value, $key);
+            $data = [];
         }
 
         if ($data instanceof Collection) {

--- a/src/Kris/LaravelFormBuilder/Fields/EntityType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/EntityType.php
@@ -49,8 +49,6 @@ class EntityType extends ChoiceType
             if (is_object($data) && method_exists($data, 'lists')) {
                 $data = $data->lists($value, $key);
             }
-        } elseif ($class instanceof Collection) {
-            $data = $class->lists($value, $key);
         } else {
             $data = [];
         }
@@ -58,7 +56,6 @@ class EntityType extends ChoiceType
         if ($data instanceof Collection) {
             $data = $data->all();
         }
-
 
         $this->options['choices'] = $data;
 


### PR DESCRIPTION
With Symfony2 you can do this :

```php

use Doctrine\ORM\EntityRepository;
// ...

$builder->add('users', 'entity', array(
    'class' => 'AcmeHelloBundle:User',
    'query_builder' => function(EntityRepository $er) {
        return $er->createQueryBuilder('u')
            ->orderBy('u.username', 'ASC');
    },
));

```

With Eloquent, the concept of repositories does not exists, so with your package we can do this :

```php

$this->add('languages', 'entity', [
        'class' => 'App\Language',
        'property' => 'short_name',
        'query_builder' => function (App\Language $lang) {
            // If query builder option is not provided, all data is fetched
            return $lang->where('active', 1);
        }
    ]);

```

If we look into your ```EntityType``` class, we can see that you new up an instance of the "class" without any parameter and it's perfectly fine, but if we use your package in a bigger project we probably use the repository pattern (as I do in my current project).

In most cases, a repository will take the ```App``` instance or the model that we'll use in the repository itself. A little tweak to make it possible in your package could be to use the ```app()``` method (from the helpers functions) to get the object that we want.

Example : 

```php

$this->add('languages', 'entity', [
        'class' => 'App\Repository\LanguagesRepository',
        'property' => 'short_name',
        'query_builder' => function (App\Repository\LanguagesRepository $repo) {
            return $repo->getActiveLanguages();
        }
    ]);

```

Not sure if it's clear enough but I'll be glad to discuss about it with you :).