### PR TITLE
`renderUntil` method - throw exception if passed a non-existent field name

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -292,7 +292,7 @@ class Form
             return $this;
         }
 
-        throw new \InvalidArgumentException('Field ['.$name.'] does not exist in '.get_class($this));
+        $this->fieldDoesNotExist($name);
     }
 
     /**
@@ -355,6 +355,10 @@ class Form
      */
     public function renderUntil($field_name, $showFormEnd = true, $showFields = true)
     {
+        if (!$this->has($field_name)) {
+            $this->fieldDoesNotExist($field_name);
+        }
+        
         $fields = $this->getUnrenderedFields();
 
         $i = 1;
@@ -381,10 +385,8 @@ class Form
         if ($this->has($name)) {
             return $this->fields[$name];
         }
-
-        throw new \InvalidArgumentException(
-            'Field with name ['. $name .'] does not exist in class '.get_class($this)
-        );
+        
+        $this->fieldDoesNotExist($name);
     }
 
     /**
@@ -1008,5 +1010,16 @@ class Form
         }
 
         return $this->validator->getMessageBag()->getMessages();
+    }
+    
+    /**
+     * Throw an exception indicating a field does not exist on the class
+     * 
+     * @param string $name
+     * @throws \InvalidArgumentException
+     */ 
+    protected function fieldDoesNotExist($name)
+    {
+        throw new \InvalidArgumentException('Field ['.$name.'] does not exist in '.get_class($this));
     }
 }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -292,6 +292,20 @@ class FormTest extends FormBuilderTestCase
 
         $this->plainForm->remove('nonexisting');
     }
+    
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
+     public function it_throws_exception_when_rendering_until_nonexisting_field()
+     {
+        $this->plainForm
+            ->add('gender', 'select')
+            ->add('name', 'text');
+
+        $this->plainForm->gender->render();
+        $this->plainForm->renderUntil('nonexisting');
+     }
 
     /**
      * @test


### PR DESCRIPTION
I spent a couple hours debugging a problem which was caused by a typo in a field name passed to the "form_until" helper function, which just wraps "renderUntil". Everything after that point was basically getting rendered twice. Ideally such a case would just be caught immediately and an exception would be thrown. Tests are passing for me. 