### PR TITLE
Update form-class-template.stub namespace position

### DIFF
--- a/src/Kris/LaravelFormBuilder/Console/stubs/form-class-template.stub
+++ b/src/Kris/LaravelFormBuilder/Console/stubs/form-class-template.stub
@@ -1,4 +1,6 @@
-<?php namespace {{namespace}};
+<?php
+
+namespace {{namespace}};
 
 use Kris\LaravelFormBuilder\Form;
 


### PR DESCRIPTION
Changes the position of the namespace definition to be the same as the new default Laravel style.