### PR TITLE
Add template prefix functionality

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -126,7 +126,7 @@ abstract class FormField
      */
     protected function getViewTemplate()
     {
-        return $this->getOption('template', $this->template);
+        return $this->parent->getTemplatePrefix() . $this->getOption('template', $this->template);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -737,6 +737,16 @@ class Form
     }
 
     /**
+     * Get template prefix that is prepended to all template paths
+     *
+     * @return string
+     */
+    public function getTemplatePrefix()
+    {
+        return $this->getFormOption('template_prefix', $this->formHelper->getConfig('template_prefix'));
+    }
+
+    /**
      * Render the form
      *
      * @param $options
@@ -770,7 +780,7 @@ class Form
      */
     protected function getTemplate()
     {
-        return $this->getFormOption('template', $this->formHelper->getConfig('form'));
+        return $this->getTemplatePrefix() . $this->getFormOption('template', $this->formHelper->getConfig('form'));
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -24,6 +24,9 @@ return [
     'collection'    => 'laravel-form-builder::collection',
     'static'        => 'laravel-form-builder::static',
 
+    // Remove the laravel-form-builder:: prefix above when using template_prefix
+    'template_prefix'   => '',
+    
     'default_namespace' => '',
 
     'custom_fields' => [

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Kris\LaravelFormBuilder\Form;
+use Kris\LaravelFormBuilder\FormHelper;
+use Kris\LaravelFormBuilder\Fields\InputType;
+
+class FormFieldTest extends FormBuilderTestCase
+{
+    /** @test */
+    public function it_uses_the_template_prefix()
+    {
+        $viewStub = $this->getMockBuilder('Illuminate\View\Factory')->setMethods(['make', 'with', 'render'])->disableOriginalConstructor()->getMock();
+        $viewStub->method('make')->willReturn($viewStub);
+        $viewStub->method('with')->willReturn($viewStub);
+
+        $helper = new FormHelper($viewStub, $this->request, $this->config);
+
+        $form = $this->formBuilder->plain();
+        $form->setFormOption('template_prefix', 'test::');
+
+        // Check that the field uses the correct template
+        $viewStub->expects($this->atLeastOnce())
+                 ->method('make')
+                 ->with($this->equalTo('test::textinput'));
+
+        $viewStub->expects($this->atLeastOnce())
+                 ->method('make')
+                 ->with($this->equalTo('test::textinput'));
+
+        $form->setFormHelper($helper);
+        
+        // Create a new field to render directly and test
+        // with the view stub generated above
+        $field = new InputType('name', 'text', $form, ['template' => 'textinput']);
+        $field->render();
+    }
+}

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -1,7 +1,8 @@
 <?php
 
-use Kris\LaravelFormBuilder\Fields\InputType;
 use Kris\LaravelFormBuilder\Form;
+use Kris\LaravelFormBuilder\FormHelper;
+use Kris\LaravelFormBuilder\Fields\InputType;
 
 class FormTest extends FormBuilderTestCase
 {
@@ -661,5 +662,37 @@ class FormTest extends FormBuilderTestCase
 
         $this->assertFalse($this->plainForm->clientValidationEnabled());
         $this->assertFalse($this->plainForm->getField('child_form')->clientValidationEnabled());
+    }
+
+    /** @test */
+    public function it_has_a_template_prefix()
+    {
+        $form = $this->formBuilder->plain();
+        $form->setFormOption('template_prefix', 'test::');
+        $form->add('name', 'text');
+
+        $this->assertEquals('test::', $form->getTemplatePrefix());
+    }
+
+    /** @test */
+    public function it_uses_the_template_prefix()
+    {
+        $viewStub = $this->getMockBuilder('Illuminate\View\Factory')->setMethods(['make', 'with', 'render'])->disableOriginalConstructor()->getMock();
+        $viewStub->method('make')->willReturn($viewStub);
+        $viewStub->method('with')->willReturn($viewStub);
+
+        $helper = new FormHelper($viewStub, $this->request, $this->config);
+
+        $form = $this->formBuilder->plain();
+        $form->setFormOption('template_prefix', 'test::');
+        $form->setFormOption('template', 'a_template');
+
+        // Check that the form uses the correct template
+        $viewStub->expects($this->atLeastOnce())
+                 ->method('make')
+                 ->with($this->equalTo('test::a_template'));
+
+        $form->setFormHelper($helper);
+        $form->renderForm();
     }
 }


### PR DESCRIPTION
This pull request adds functionality to define a template prefix for a form. It should be fully backwards compatible.

The goal of this change is the ability to quickly copy an entire views/form directory and create an entirely new styling for a form. Using this new style for all the form fields in a form is as simple as setting the `template_prefix` option for the `Form`. This template prefix trickles down into the `getViewTemplate` method for `FormField` as well.

3 tests have been added to check functionality.

If you have any questions or think something should work/be configured differently, I'm happy to discuss!