### PR TITLE
Cleanup template_prefix code

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -100,6 +100,11 @@ class Form
     protected $rebuilding = false;
 
     /**
+     * @var string
+     */
+    protected $templatePrefix;
+
+    /**
      * Build the form
      *
      * @return mixed
@@ -451,6 +456,7 @@ class Form
         $this->pullFromOptions('data', 'addData');
         $this->pullFromOptions('errors_enabled', 'setErrorsEnabled');
         $this->pullFromOptions('client_validation', 'setClientValidationEnabled');
+        $this->pullFromOptions('template_prefix', 'setTemplatePrefix');
 
         return $this;
     }
@@ -743,7 +749,24 @@ class Form
      */
     public function getTemplatePrefix()
     {
-        return $this->getFormOption('template_prefix', $this->formHelper->getConfig('template_prefix'));
+        if ($this->templatePrefix !== null) {
+            return $this->templatePrefix;
+        }
+
+        return $this->formHelper->getConfig('template_prefix');
+    }
+
+    /**
+     * Set a template prefix for the form and its fields
+     *
+     * @param string $prefix
+     * @return $this
+     */
+    public function setTemplatePrefix($prefix)
+    {
+        $this->templatePrefix = (string) $prefix;
+
+        return $this;
     }
 
     /**

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -16,7 +16,7 @@ class FormFieldTest extends FormBuilderTestCase
         $helper = new FormHelper($viewStub, $this->request, $this->config);
 
         $form = $this->formBuilder->plain();
-        $form->setFormOption('template_prefix', 'test::');
+        $form->setTemplatePrefix('test::');
 
         // Check that the field uses the correct template
         $viewStub->expects($this->atLeastOnce())

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -668,10 +668,20 @@ class FormTest extends FormBuilderTestCase
     public function it_has_a_template_prefix()
     {
         $form = $this->formBuilder->plain();
-        $form->setFormOption('template_prefix', 'test::');
+        $form->setFormOptions(['template_prefix' => 'test::']);
         $form->add('name', 'text');
 
         $this->assertEquals('test::', $form->getTemplatePrefix());
+        $this->assertNull($form->getFormOption('template_prefix'));
+    }
+
+    /** @test */
+    public function it_stores_a_template_prefix()
+    {
+        $form = $this->formBuilder->plain();
+        $form->setTemplatePrefix('test_prefix::');
+
+        $this->assertEquals('test_prefix::', $form->getTemplatePrefix());
     }
 
     /** @test */
@@ -684,8 +694,10 @@ class FormTest extends FormBuilderTestCase
         $helper = new FormHelper($viewStub, $this->request, $this->config);
 
         $form = $this->formBuilder->plain();
-        $form->setFormOption('template_prefix', 'test::');
-        $form->setFormOption('template', 'a_template');
+        $form->setFormOptions([
+            'template_prefix' => 'test::',
+            'template' => 'a_template'
+        ]);
 
         // Check that the form uses the correct template
         $viewStub->expects($this->atLeastOnce())


### PR DESCRIPTION
Before using setFormOptions it would not correctly pull template_prefix
from the options. Leaving it in caused it to be displayed as an
attribute on the form.

I made a separate setter for the template prefix and followed the logic
used for other settings in setFormOptions.

Sorry for the inconvenience and the oversight in my previous pull
request!