### PR TITLE
fixed falsy checkboxes not being saved by adding a hidden input with the same name

### DIFF
--- a/src/views/checkbox.php
+++ b/src/views/checkbox.php
@@ -5,6 +5,7 @@
 <?php endif; ?>
 
 <?php if ($showField): ?>
+    <?= Form::hidden($name, false) ?>
     <?= Form::checkbox($name, $options['value'], $options['checked'], $options['attr']) ?>
 
     <?php include 'help_block.php' ?>


### PR DESCRIPTION
I probably did not find out how to handle this because it should be a pretty common issue: unchecked checkboxes won't be included in the POST data, so after checking a checkbox, it's impossible to uncheck it.

One can check each field for existence in the controller, or simply add a hidden input with the same name BEFORE the checkbox as I did here.