### PR TITLE
Add localizable names/label functionality

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -81,7 +81,8 @@ class ChildFormType extends ParentType
         if (is_string($class)) {
             $options = [
                 'model' => $this->parent->getModel(),
-                'name' => $this->name
+                'name' => $this->name,
+                'language_name' => $this->parent->getLanguageName()
             ];
 
             if (!$this->parent->clientValidationEnabled()) {
@@ -105,6 +106,10 @@ class ChildFormType extends ParentType
 
             if (!$class->getData()) {
                 $class->addData($this->parent->getData());
+            }
+
+            if (!$class->getLanguageName()) {
+                $class->setLanguageName($this->parent->getLanguageName());
             }
 
             if (!$this->parent->clientValidationEnabled()) {

--- a/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
@@ -97,7 +97,7 @@ class ChoiceType extends ParentType
                 [
                     'attr'       => ['id' => $id],
                     'label_attr' => ['for' => $id],
-                    'label'      => $this->formHelper->formatLabel($choice),
+                    'label'      => $choice,
                     'checked'    => in_array($key, (array)$this->options[$this->valueProperty]),
                     'value'      => $key
                 ]

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -407,7 +407,7 @@ abstract class FormField
             ]],
             'value' => null,
             'default_value' => null,
-            'label' => $this->formHelper->formatLabel($this->getRealName()),
+            'label' => $this->formHelper->formatLabel($this->parent->getLocalizableName($this->getRealName())),
             'is_child' => false,
             'label_attr' => ['class' => $this->formHelper->getConfig('defaults.label_class')],
             'errors' => ['class' => $this->formHelper->getConfig('defaults.error_class')],

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -105,6 +105,11 @@ class Form
     protected $templatePrefix;
 
     /**
+     * @var string
+     */
+    protected $languageName;
+
+    /**
      * Build the form
      *
      * @return mixed
@@ -461,6 +466,7 @@ class Form
         $this->pullFromOptions('errors_enabled', 'setErrorsEnabled');
         $this->pullFromOptions('client_validation', 'setClientValidationEnabled');
         $this->pullFromOptions('template_prefix', 'setTemplatePrefix');
+        $this->pullFromOptions('language_name', 'setLanguageName');
 
         return $this;
     }
@@ -790,6 +796,30 @@ class Form
     }
 
     /**
+     * Get the 'lookup' key for a localizable label name
+     *
+     * @param string $label
+     * @return $this
+     */
+    public function getLocalizableName($label)
+    {
+        return ($this->languageName ? $this->languageName . '.' : '') . $label;
+    }
+
+    /**
+     * Set a language name, used as prefix for translated strings
+     *
+     * @param string $prefix
+     * @return $this
+     */
+    public function setLanguageName($prefix)
+    {
+        $this->languageName = (string) $prefix;
+
+        return $this;
+    }
+
+    /**
      * Render the form
      *
      * @param $options
@@ -893,7 +923,7 @@ class Form
         }
 
         if (!isset($options['label'])) {
-            $options['label'] = $this->formHelper->formatLabel($name);
+            $options['label'] = $this->formHelper->formatLabel($this->getLocalizableName($name));
         }
     }
 

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -807,6 +807,16 @@ class Form
     }
 
     /**
+     * Get the language name
+     *
+     * @return string
+     */
+    public function getLanguageName()
+    {
+        return $this->languageName;
+    }
+
+    /**
      * Set a language name, used as prefix for translated strings
      *
      * @param string $prefix

--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -42,7 +42,7 @@ class FormBuilderServiceProvider extends ServiceProvider
 
             $configuration = $app['config']->get('laravel-form-builder');
 
-            return new FormHelper($app['view'], $configuration, $app['translator']);
+            return new FormHelper($app['view'], $app['translator'], $configuration);
         });
 
         $this->app->alias('laravel-form-helper', 'Kris\LaravelFormBuilder\FormHelper');

--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -42,7 +42,7 @@ class FormBuilderServiceProvider extends ServiceProvider
 
             $configuration = $app['config']->get('laravel-form-builder');
 
-            return new FormHelper($app['view'], $configuration);
+            return new FormHelper($app['view'], $configuration, $app['translator']);
         });
 
         $this->app->alias('laravel-form-helper', 'Kris\LaravelFormBuilder\FormHelper');

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -1,9 +1,10 @@
 <?php  namespace Kris\LaravelFormBuilder;
 
-use Illuminate\Contracts\View\Factory as View;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
+use Illuminate\Translation\Translator;
+use Illuminate\Database\Eloquent\Model;
 use Kris\LaravelFormBuilder\Fields\FormField;
+use Illuminate\Contracts\View\Factory as View;
 
 class FormHelper
 {
@@ -12,6 +13,11 @@ class FormHelper
      * @var View
      */
     protected $view;
+
+    /**
+     * @var Translator
+     */
+    protected $translator;
 
     /**
      * @var array
@@ -72,9 +78,10 @@ class FormHelper
      * @param View    $view
      * @param array   $config
      */
-    public function __construct(View $view, array $config = [])
+    public function __construct(View $view, array $config = [], Translator $translator)
     {
         $this->view = $view;
+        $this->translator = $translator;
         $this->config = $config;
         $this->loadCustomTypes();
     }
@@ -222,6 +229,10 @@ class FormHelper
     {
         if (!$name) {
             return null;
+        }
+
+        if ($this->translator->has($name)) {
+            return $this->translator->get($name);
         }
 
         return ucfirst(str_replace('_', ' ', $name));

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -76,9 +76,10 @@ class FormHelper
 
     /**
      * @param View    $view
+     * @param Translator $translator
      * @param array   $config
      */
-    public function __construct(View $view, array $config = [], Translator $translator)
+    public function __construct(View $view, Translator $translator, array $config = [])
     {
         $this->view = $view;
         $this->translator = $translator;

--- a/tests/Fields/ChildFormTypeTest.php
+++ b/tests/Fields/ChildFormTypeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Kris\LaravelFormBuilder\Fields\ChoiceType;
+use Kris\LaravelFormBuilder\Fields\CollectionType;
+use Kris\LaravelFormBuilder\Fields\SelectType;
+use Kris\LaravelFormBuilder\Form;
+
+class ChildFormTypeTest extends FormBuilderTestCase
+{
+    /** @test */
+    public function it_implicitly_inherits_language_name()
+    {
+        $plainParent = $this->formBuilder->plain(['language_name' => 'test_name']);
+        $plainChild = $this->formBuilder->plain();
+
+        $plainParent->add('a form', 'form', ['class' => $plainChild]);
+
+        $this->assertEquals($plainParent->getLanguageName(), $plainChild->getLanguageName());
+        $this->assertEquals('test_name', $plainChild->getLanguageName());
+    }
+
+    /** @test */
+    public function it_does_not_overwrite_language_name()
+    {
+        $plainParent = $this->formBuilder->plain(['language_name' => 'test_name']);
+        $plainChild = $this->formBuilder->plain(['language_name' => 'different_name']);
+
+        $plainParent->add('a form', 'form', ['class' => $plainChild]);
+
+        $this->assertEquals('different_name', $plainChild->getLanguageName());
+        $this->assertEquals('test_name', $plainParent->getLanguageName());
+    }
+}

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -13,7 +13,7 @@ class FormFieldTest extends FormBuilderTestCase
         $viewStub->method('make')->willReturn($viewStub);
         $viewStub->method('with')->willReturn($viewStub);
 
-        $helper = new FormHelper($viewStub, $this->config, $this->translator);
+        $helper = new FormHelper($viewStub, $this->translator, $this->config);
 
         $form = $this->formBuilder->plain();
         $form->setTemplatePrefix('test::');

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -13,7 +13,7 @@ class FormFieldTest extends FormBuilderTestCase
         $viewStub->method('make')->willReturn($viewStub);
         $viewStub->method('with')->willReturn($viewStub);
 
-        $helper = new FormHelper($viewStub, $this->config);
+        $helper = new FormHelper($viewStub, $this->config, $this->translator);
 
         $form = $this->formBuilder->plain();
         $form->setTemplatePrefix('test::');

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -95,7 +95,7 @@ namespace {
             $form =  new LaravelFormBuilderTest\Forms\NamespacedDummyForm();
             $config = $this->config;
             $config['default_namespace'] = 'LaravelFormBuilderTest\Forms';
-            $formHelper = new FormHelper($this->view, $config, $this->translator);
+            $formHelper = new FormHelper($this->view, $this->translator, $config);
             $formBuilder = new FormBuilder($this->app, $formHelper);
 
             $formBuilder->create('NamespacedDummyForm');

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -95,7 +95,7 @@ namespace {
             $form =  new LaravelFormBuilderTest\Forms\NamespacedDummyForm();
             $config = $this->config;
             $config['default_namespace'] = 'LaravelFormBuilderTest\Forms';
-            $formHelper = new FormHelper($this->view, $config);
+            $formHelper = new FormHelper($this->view, $config, $this->translator);
             $formBuilder = new FormBuilder($this->app, $formHelper);
 
             $formBuilder->create('NamespacedDummyForm');

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -77,7 +77,7 @@ abstract class FormBuilderTestCase extends TestCase {
         $this->model = new TestModel();
         $this->config = include __DIR__.'/../src/config/config.php';
 
-        $this->formHelper = new FormHelper($this->view, $this->config, $this->translator);
+        $this->formHelper = new FormHelper($this->view, $this->translator, $this->config);
         $this->formBuilder = new FormBuilder($this->app, $this->formHelper);
 
         $this->plainForm = $this->formBuilder->plain();

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -21,6 +21,11 @@ abstract class FormBuilderTestCase extends TestCase {
     protected $view;
 
     /**
+     * @var \Illuminate\Translation\Translator
+     */
+    protected $translator;
+
+    /**
      * @var \Illuminate\Http\Request
      */
     protected $request;
@@ -65,13 +70,14 @@ abstract class FormBuilderTestCase extends TestCase {
         parent::setUp();
 
         $this->view = $this->app['view'];
+        $this->translator = $this->app['translator'];
         $this->request = $this->app['request'];
         $this->request->setSession($this->app['session.store']);
         $this->validatorFactory = $this->app['validator'];
         $this->model = new TestModel();
         $this->config = include __DIR__.'/../src/config/config.php';
 
-        $this->formHelper = new FormHelper($this->view, $this->config);
+        $this->formHelper = new FormHelper($this->view, $this->config, $this->translator);
         $this->formBuilder = new FormBuilder($this->app, $this->formHelper);
 
         $this->plainForm = $this->formBuilder->plain();

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -98,7 +98,7 @@ class FormHelperTest extends FormBuilderTestCase
 
         $config['custom_fields']['datetime'] = 'App\Forms\DatetimeType';
 
-        $formHelper = new FormHelper($this->view, $config);
+        $formHelper = new FormHelper($this->view, $config, $this->translator);
 
         $this->assertEquals(
             'App\Forms\DatetimeType',

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -98,7 +98,7 @@ class FormHelperTest extends FormBuilderTestCase
 
         $config['custom_fields']['datetime'] = 'App\Forms\DatetimeType';
 
-        $formHelper = new FormHelper($this->view, $config, $this->translator);
+        $formHelper = new FormHelper($this->view, $this->translator, $config);
 
         $this->assertEquals(
             'App\Forms\DatetimeType',

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -361,6 +361,18 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_can_generate_a_localizable_name()
+    {
+        $options = [
+            'language_name' => 'test_form'
+        ];
+
+        $this->plainForm->setFormOptions($options);
+
+        $this->assertEquals('test_form.some_field', $this->plainForm->getLocalizableName('some_field'));
+    }
+
+    /** @test */
     public function it_can_set_form_options_with_setters()
     {
         $this->plainForm->setMethod('DELETE');
@@ -725,7 +737,7 @@ class FormTest extends FormBuilderTestCase
         $viewStub->method('make')->willReturn($viewStub);
         $viewStub->method('with')->willReturn($viewStub);
 
-        $helper = new FormHelper($viewStub, $this->config);
+        $helper = new FormHelper($viewStub, $this->config, $this->translator);
 
         $form = $this->formBuilder->plain();
         $form->setFormOptions([

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -737,7 +737,7 @@ class FormTest extends FormBuilderTestCase
         $viewStub->method('make')->willReturn($viewStub);
         $viewStub->method('with')->willReturn($viewStub);
 
-        $helper = new FormHelper($viewStub, $this->config, $this->translator);
+        $helper = new FormHelper($viewStub, $this->translator, $this->config);
 
         $form = $this->formBuilder->plain();
         $form->setFormOptions([


### PR DESCRIPTION
As discussed in kristijanhusak/laravel-form-builder#206

I'm not sure this is the best way to go about this, but I'm submitting this pull request to start a discussion.

I've opted not to do the generation of the localizable name in the `FormHelper`, because there is no real connection to the form. In addition to that, `FormHelper` is defined as a singleton so setting a language string would make little sense in there.

I have also removed a piece of code from the `choices` field. As described in that commit:

> The array passed is a key value array. To me, it doesn't make sense to pass this value through the label formatter, since it will change (intended) underscores to spaces.

Furthermore, I have only 'enabled' implicit localization for labels that are implicitly determined. I.e.: for select and choice labels, they are passed directly using their key value arrays.