### PR TITLE
Add functionality to add required class based on rules

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -216,6 +216,8 @@ abstract class FormField
         $helper = $this->formHelper;
         $rulesParser = new RulesParser($this);
         $rules = $this->getOption('rules');
+        $parsedRules = $rules ? $rulesParser->parse($rules) : [];
+
         $this->options = $helper->mergeOptions($this->options, $options);
 
         if ($this->getOption('attr.multiple') && !$this->getOption('tmp.multipleBracesSet')) {
@@ -227,7 +229,7 @@ abstract class FormField
             $this->addErrorClass();
         }
 
-        if ($this->getOption('required') === true || $rulesParser->containsRequired($rules)) {
+        if ($this->getOption('required') === true || isset($parsedRules['required'])) {
             $lblClass = $this->getOption('label_attr.class', '');
             $requiredClass = $helper->getConfig('defaults.required_class', 'required');
             if (!str_contains($lblClass, $requiredClass)) {
@@ -238,7 +240,7 @@ abstract class FormField
         }
 
         if ($this->parent->clientValidationEnabled() && $rules) {
-            $attrs = $this->getOption('attr') + $rulesParser->parse($rules);
+            $attrs = $this->getOption('attr') + $parsedRules;
             $this->setOption('attr', $attrs);
         }
 

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -1,4 +1,6 @@
-<?php  namespace Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace Kris\LaravelFormBuilder\Fields;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
@@ -212,6 +214,8 @@ abstract class FormField
     protected function prepareOptions(array $options = [])
     {
         $helper = $this->formHelper;
+        $rulesParser = new RulesParser($this);
+        $rules = $this->getOption('rules');
         $this->options = $helper->mergeOptions($this->options, $options);
 
         if ($this->getOption('attr.multiple') && !$this->getOption('tmp.multipleBracesSet')) {
@@ -223,7 +227,7 @@ abstract class FormField
             $this->addErrorClass();
         }
 
-        if ($this->getOption('required') === true) {
+        if ($this->getOption('required') === true || $rulesParser->containsRequired($rules)) {
             $lblClass = $this->getOption('label_attr.class', '');
             $requiredClass = $helper->getConfig('defaults.required_class', 'required');
             if (!str_contains($lblClass, $requiredClass)) {
@@ -233,8 +237,7 @@ abstract class FormField
             }
         }
 
-        if ($this->parent->clientValidationEnabled() && $rules = $this->getOption('rules')) {
-            $rulesParser = new RulesParser($this);
+        if ($this->parent->clientValidationEnabled() && $rules) {
             $attrs = $this->getOption('attr') + $rulesParser->parse($rules);
             $this->setOption('attr', $attrs);
         }

--- a/src/Kris/LaravelFormBuilder/RulesParser.php
+++ b/src/Kris/LaravelFormBuilder/RulesParser.php
@@ -55,6 +55,22 @@ class RulesParser
     }
 
     /**
+     * Checks if the ruleset contains the required rule.
+     *
+     * @param  string|array  $rules
+     * @return bool
+     */
+    public function containsRequired($rules)
+    {
+        $rules = (is_string($rules)) ? explode('|', $rules) : $rules;
+
+        // We are only looking for the basic 'required'
+        // rule, so there is no need to loop through
+        // the rules and parse their parameters.
+        return array_search('required', $rules) !== false;
+    }
+
+    /**
      * Check that a checkbox is accepted. Needs yes, on, 1, or true as value.
      *
      *   accepted  -> required="required"
@@ -577,5 +593,4 @@ class RulesParser
         }
         return str_getcsv($parameter);
     }
-
 }

--- a/src/Kris/LaravelFormBuilder/RulesParser.php
+++ b/src/Kris/LaravelFormBuilder/RulesParser.php
@@ -55,22 +55,6 @@ class RulesParser
     }
 
     /**
-     * Checks if the ruleset contains the required rule.
-     *
-     * @param  string|array  $rules
-     * @return bool
-     */
-    public function containsRequired($rules)
-    {
-        $rules = (is_string($rules)) ? explode('|', $rules) : $rules;
-
-        // We are only looking for the basic 'required'
-        // rule, so there is no need to loop through
-        // the rules and parse their parameters.
-        return array_search('required', $rules) !== false;
-    }
-
-    /**
      * Check that a checkbox is accepted. Needs yes, on, 1, or true as value.
      *
      *   accepted  -> required="required"

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -34,4 +34,30 @@ class FormFieldTest extends FormBuilderTestCase
         $field = new InputType('name', 'text', $form, ['template' => 'textinput']);
         $field->render();
     }
+
+    /** @test */
+    public function it_sets_the_required_attribute_explicitly()
+    {
+        $options = [
+            'required' => true
+        ];
+
+        $hidden = new InputType('hidden_id', 'hidden', $this->plainForm, $options);
+        $hidden->render();
+
+        $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
+    }
+
+    /** @test */
+    public function it_sets_the_required_attribute_implicitly()
+    {
+        $options = [
+            'rules' => 'required|min:3'
+        ];
+
+        $hidden = new InputType('hidden_id', 'hidden', $this->plainForm, $options);
+        $hidden->render();
+
+        $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
+    }
 }

--- a/tests/RulesParserTest.php
+++ b/tests/RulesParserTest.php
@@ -40,6 +40,27 @@ class RulesParserTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_checks_if_rules_contain_required()
+    {
+        $this->assertTrue(
+            $this->parser->containsRequired('required|min:10')
+        );
+
+        $this->assertTrue(
+            $this->parser->containsRequired(['required', 'min:10'])
+        );
+
+        $this->assertFalse(
+            $this->parser->containsRequired('in:a|b|c')
+        );
+
+        // Only the 'basic' require should be found
+        $this->assertFalse(
+            $this->parser->containsRequired(['required_with:some_field'])
+        );
+    }
+
+    /** @test */
     public function it_parses_the_accepted_rule()
     {
         $this->assertEquals(

--- a/tests/RulesParserTest.php
+++ b/tests/RulesParserTest.php
@@ -40,27 +40,6 @@ class RulesParserTest extends FormBuilderTestCase
     }
 
     /** @test */
-    public function it_checks_if_rules_contain_required()
-    {
-        $this->assertTrue(
-            $this->parser->containsRequired('required|min:10')
-        );
-
-        $this->assertTrue(
-            $this->parser->containsRequired(['required', 'min:10'])
-        );
-
-        $this->assertFalse(
-            $this->parser->containsRequired('in:a|b|c')
-        );
-
-        // Only the 'basic' require should be found
-        $this->assertFalse(
-            $this->parser->containsRequired(['required_with:some_field'])
-        );
-    }
-
-    /** @test */
     public function it_parses_the_accepted_rule()
     {
         $this->assertEquals(


### PR DESCRIPTION
As discussed in kristijanhusak/laravel-form-builder#206

This change should be fairly straightforward and shouldn't break existing code. The only side effect might be that the `required` class is added where the user does have the `required` rule but didn't have the `required` option before.

