### PR TITLE
Add check for nested translations

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -233,7 +233,11 @@ class FormHelper
         }
 
         if ($this->translator->has($name)) {
-            return $this->translator->get($name);
+            $translatedName = $this->translator->get($name);
+
+            if (is_string($translatedName)) {
+                return $translatedName;
+            }
         }
 
         return ucfirst(str_replace('_', ' ', $name));

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -98,11 +98,15 @@ class FormFieldTest extends FormBuilderTestCase
         $options = [
             'language_name' => 'validation'
         ];
-        $customPlainForm = $this->formBuilder->plain();
 
+        $customPlainForm = $this->formBuilder->plain();
 
         $this->plainForm->setFormOptions($options)->add('nonexisting', 'text');
         $customPlainForm->add('the_name_without_translation', 'text');
+
+        // Case where translation is nested (an array) should be invalid and fallback
+        // in validation translation file the custom key does this
+        $customPlainForm->add('custom', 'text');
 
         $this->assertEquals(
             'Validation.nonexisting',
@@ -112,6 +116,11 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertEquals(
             'The name without translation',
             $customPlainForm->the_name_without_translation->getOption('label')
+        );
+
+        $this->assertEquals(
+            'Custom',
+            $customPlainForm->custom->getOption('label')
         );
     }
 }


### PR DESCRIPTION
Laravel translations can be nested and thus the translator will return
an array for these types of translations.  Passing an array into the
FormBuilder where is it expecting a string results in an error when the
form is rendered due to htmlentities not knowing what to do with an
array.  This change akes sure that the returned translation is actually
a string before using it.

I also updated the test to check for this case.