### PR TITLE
Prepared FormBuilder to be compatible with Laravel 5.3+

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -75,13 +75,14 @@ class FormBuilderServiceProvider extends ServiceProvider
 
             $this->app->singleton('form', function($app) {
 
-                // LaravelCollective\HtmlBuilder 5.2 is not backward compatible and will throw an exeption
-                // https://github.com/kristijanhusak/laravel-form-builder/commit/a36c4b9fbc2047e81a79ac8950d734e37cd7bfb0
-                if (substr(Application::VERSION, 0, 3) == '5.2') {
-                    $form = new LaravelForm($app['html'], $app['url'], $app['view'], $app['session.store']->getToken());
+                // LaravelCollective\HtmlBuilder 5.2 is not backward compatible and will throw an exception
+                $version = substr(Application::VERSION, 0, 3);
+
+                if (str_is('5.0', $version) || str_is('5.1', $version)) {
+                    $form = new LaravelForm($app[ 'html' ], $app[ 'url' ], $app[ 'session.store' ]->getToken());
                 }
                 else {
-                    $form = new LaravelForm($app['html'], $app['url'], $app['session.store']->getToken());
+                    $form = new LaravelForm($app['html'], $app['url'], $app['view'], $app['session.store']->getToken());
                 }
 
                 return $form->setSessionStore($app['session.store']);


### PR DESCRIPTION
When I fixed FormBuilder to be compatible with Laravel < 5.2, I implemented a stupid fix that might throw an exception on Laravel 5.3+.