### PR TITLE
#246 +Form->getValidatedValues()

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -41,6 +41,15 @@ class ChildFormType extends ParentType
     }
 
     /**
+     * @inheritdoc
+     */
+    public function getAllAttributes()
+    {
+        // Collect all children's attributes.
+        return $this->parent->getFormHelper()->mergeAttributes($this->children);
+    }
+
+    /**
      * @return mixed|void
      */
     protected function createChildren()

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -587,6 +587,16 @@ abstract class FormField
     }
 
     /**
+     * Get this field's attributes, probably just one.
+     *
+     * @return array
+     */
+    public function getAllAttributes()
+    {
+        return [$this->getNameKey()];
+    }
+
+    /**
      * Get value property
      *
      * @param mixed|null $default

--- a/src/Kris/LaravelFormBuilder/Fields/StaticType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/StaticType.php
@@ -35,4 +35,13 @@ class StaticType extends FormField
             'attr' => ['class' => 'form-control-static', 'id' => $this->getName()]
         ];
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAllAttributes()
+    {
+        // No input allowed for Static fields.
+        return [];
+    }
 }

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1120,7 +1120,7 @@ class Form
      *
      * @return array
      */
-    public function getFormValues($with_nulls = true)
+    public function getFieldValues($with_nulls = true)
     {
         $request_values = $this->getRequest()->all();
 

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -3,6 +3,7 @@
 use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 use Kris\LaravelFormBuilder\Fields\FormField;
 
 class Form
@@ -1056,6 +1057,16 @@ class Form
     }
 
     /**
+     * Get all form field attributes, including child forms, in a flat array.
+     *
+     * @return array
+     */
+    public function getAllAttributes()
+    {
+        return $this->formHelper->mergeAttributes($this->fields);
+    }
+
+    /**
      * Check if the form is valid
      *
      * @return bool
@@ -1086,6 +1097,26 @@ class Form
         }
 
         return $this->validator->getMessageBag()->getMessages();
+    }
+
+    /**
+     * Get all Request values from all fields, and nothing else.
+     *
+     * @return array
+     */
+    public function getValidatedValues($with_nulls = true)
+    {
+        $request_values = $this->getRequest()->all();
+
+        $values = [];
+        foreach ($this->getAllAttributes() as $attribute) {
+            $value = Arr::get($request_values, $attribute);
+            if ($with_nulls || $value !== null) {
+                Arr::set($values, $attribute, $value);
+            }
+        }
+
+        return $values;
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1104,7 +1104,7 @@ class Form
      *
      * @return array
      */
-    public function getValidatedValues($with_nulls = true)
+    public function getFormValues($with_nulls = true)
     {
         $request_values = $this->getRequest()->all();
 

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -276,6 +276,19 @@ class FormHelper
     }
 
     /**
+     * @return array
+     */
+    public function mergeAttributes($fields)
+    {
+        $attributes = [];
+        foreach ($fields as $field) {
+            $attributes = array_merge($attributes, $field->getAllAttributes());
+        }
+
+        return $attributes;
+    }
+
+    /**
      * @param string $string
      * @return string
      */

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -144,7 +144,7 @@ class FormTest extends FormBuilderTestCase
             ]);
 
         $this->request['description'] = 'some long description';
-        
+
         try {
             $this->plainForm->redirectIfNotValid('my-custom-destination');
             $this->fail('Expected an HttpResponseException, but was allowed to continue');
@@ -309,14 +309,14 @@ class FormTest extends FormBuilderTestCase
         // Ignore unknown data, skip missing input
         $this->assertEquals(
             $check_values,
-            $this->plainForm->getFormValues(false)
+            $this->plainForm->getFieldValues(false)
         );
 
         // Ignore unknown data, add NIL for missing input
         $check_values['user']['address']['number'] = null;
         $this->assertEquals(
             $check_values,
-            $this->plainForm->getFormValues()
+            $this->plainForm->getFieldValues()
         );
     }
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -232,14 +232,14 @@ class FormTest extends FormBuilderTestCase
         // Ignore unknown data, skip missing input
         $this->assertEquals(
             $check_values,
-            $this->plainForm->getValidatedValues(false)
+            $this->plainForm->getFormValues(false)
         );
 
         // Ignore unknown data, add NIL for missing input
         $check_values['user']['address']['number'] = null;
         $this->assertEquals(
             $check_values,
-            $this->plainForm->getValidatedValues()
+            $this->plainForm->getFormValues()
         );
     }
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -192,6 +192,58 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_returns_validated_values()
+    {
+        $this->plainForm
+            ->add('name', 'text', [
+                'rules' => ['required', 'min:20', 'max:255'],
+            ])
+            ->add('description[text]', 'textarea')
+            ->add('address', 'form', [
+                'class' => $this->formBuilder->plain()
+                    ->add('street[name]', 'text', ['rules' => 'required']),
+            ])
+            ->add('user[address]', 'form', [
+                'class' => $this->formBuilder->plain()
+                    ->add('street', 'text', ['rules' => 'required'])
+                    ->add('number', 'number'),
+            ]);
+
+        // Should return all fields, including nested, no matter validation rules
+        $this->assertEquals(
+            ['name', 'description.text', 'address.street.name', 'user.address.street', 'user.address.number'],
+            $this->plainForm->getAllAttributes()
+        );
+
+        $this->request['status'] = 1;
+        $this->request['role'] = 'admin';
+        $this->request['name'] = 'Foo';
+        $this->request['description'] = ['text' => 'Foo Bar'];
+        $this->request['address'] = ['street' => ['id' => 1000, 'name' => 'Street 1']];
+        $this->request['user'] = ['id' => 1000, 'address' => ['street' => 'Street 2']]; // Missing optional 'number'
+
+        $check_values = [
+            'name' => 'Foo',
+            'description' => ['text' => 'Foo Bar'],
+            'address' => ['street' => ['name' => 'Street 1']],
+            'user' => ['address' => ['street' => 'Street 2']],
+        ];
+
+        // Ignore unknown data, skip missing input
+        $this->assertEquals(
+            $check_values,
+            $this->plainForm->getValidatedValues(false)
+        );
+
+        // Ignore unknown data, add NIL for missing input
+        $check_values['user']['address']['number'] = null;
+        $this->assertEquals(
+            $check_values,
+            $this->plainForm->getValidatedValues()
+        );
+    }
+
+    /** @test */
     public function it_adds_after_some_field()
     {
         $this->plainForm


### PR DESCRIPTION
Adds a public `$form->getValidatedValues()` function to extract all Request values according to the submitted form, not according to the submitted data. Uses all fields' `getAllAttributes()` to collect a flat list of all attributes, including all child forms and theirs etc.

The main function (`getValidatedValues`) is somewhat of a misnomer, because it doesn't actually validate, and the returned values don't have to be validated in order to call it, but I couldn't find a better name.

**Usage:** instead of

    $values = $request->all();

call

    $values = $form->getValidatedValues();
