### PR TITLE
#243 +showLabel field option

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -144,6 +144,9 @@ abstract class FormField
         $value = $this->getValue();
         $defaultValue = $this->getDefaultValue();
 
+        // Let the field definition choose whether to show the label.
+        $showLabel = $this->getOption('showLabel', $showLabel);
+
         if ($showField) {
             $this->rendered = true;
         }


### PR DESCRIPTION
Very simply takes the optional option from the field config.

This way isn't perfect IMO, because this way the field config overrides the runtime `render()` param. I'd like it to be the opposite: the renderer has final say whether to show the label, and if it doesn't have a preference (NULL), the field config is used. To do that, the `render()` param requires a default NULL value that will be converted to a bool in combination with the option:

```
public function render(array $options = [], $showLabel = null, $showField = true, $showError = true) {
    // ..
    if ($showLabel === null) {
        $showLabel = $this->getOption('showLabel', true); // TRUE is still the default default
    }
```

but that requires the NULL param to be the default everywhere, and that seems impossible, because this method is called from many places, where TRUE is still the default.

So this PR is second best: if the field config exists, it always wins.