### PR TITLE
#250 bugfix in doubly nested field name

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -997,12 +997,17 @@ class Form
      */
     protected function getFieldName($name)
     {
-        if ($this->getName() !== null) {
-            return $this->formHelper->transformToBracketSyntax(
-                $this->formHelper->transformToDotSyntax(
-                    $this->getName() . '[' . $name . ']'
-                )
-            );
+        $formName = $this->getName();
+        if ($formName !== null) {
+            if (strpos($formName, '[') !== false || strpos($formName, ']') !== false) {
+                return $this->formHelper->transformToBracketSyntax(
+                    $this->formHelper->transformToDotSyntax(
+                        $formName . '[' . $name . ']'
+                    )
+                );
+            }
+
+            return $formName . '[' . $name . ']';
         }
 
         return $name;

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -997,7 +997,11 @@ class Form
     protected function getFieldName($name)
     {
         if ($this->getName() !== null) {
-            return $this->getName().'['.$name.']';
+            return $this->formHelper->transformToBracketSyntax(
+                $this->formHelper->transformToDotSyntax(
+                    $this->getName() . '[' . $name . ']'
+                )
+            );
         }
 
         return $name;

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -285,6 +285,21 @@ class FormHelper
     }
 
     /**
+     * @param string $string
+     * @return string
+     */
+    public function transformToBracketSyntax($string)
+    {
+        $name = explode('.', $string);
+        if (count($name) == 1) {
+            return $name[0];
+        }
+
+        $first = array_shift($name);
+        return $first . '[' . implode('][', $name) . ']';
+    }
+
+    /**
      * @return TranslatorInterface
      */
     public function getTranslator()

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -638,6 +638,19 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_has_html_valid_element_names()
+    {
+        $this->plainForm
+            ->add('name[text]', 'text')
+            ->add('child[form]', 'form', [
+                'class' => $this->formBuilder->plain()->add('name[text]', 'text'),
+            ]);
+
+        $this->assertEquals('name[text]', $this->plainForm->getField('name[text]')->getName());
+        $this->assertEquals('child[form][name][text]', $this->plainForm->getField('child[form]')->getField('name[text]')->getName());
+    }
+
+    /** @test */
     public function it_adds_custom_type()
     {
         $this->plainForm->addCustomField('datetime', 'Some\\Namespace\\DatetimeType');


### PR DESCRIPTION
Added `FormHelper->transformToBracketSyntax()`, which helps in fixing the field's name. It's not super pretty, but I think it handles all cases.