### PR TITLE
#253 Added events

### DIFF
--- a/src/Kris/LaravelFormBuilder/Events/AfterFieldCreation.php
+++ b/src/Kris/LaravelFormBuilder/Events/AfterFieldCreation.php
@@ -1,0 +1,40 @@
+<?php namespace Kris\LaravelFormBuilder\Events;
+
+use Kris\LaravelFormBuilder\Fields\FormField;
+use Kris\LaravelFormBuilder\Form;
+
+class AfterFieldCreation {
+
+    /**
+     * @var $form Form
+     */
+    protected $form;
+
+    /**
+     * @var $field FormField
+     */
+    protected $field;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Form $form, FormField $field) {
+        $this->form = $form;
+        $this->field = $field;
+    }
+
+    /**
+     * Return the event's form.
+     */
+    public function getForm() {
+        return $this->form;
+    }
+
+    /**
+     * Return the event's field.
+     */
+    public function getField() {
+        return $this->field;
+    }
+
+}

--- a/src/Kris/LaravelFormBuilder/Events/AfterFormCreation.php
+++ b/src/Kris/LaravelFormBuilder/Events/AfterFormCreation.php
@@ -1,0 +1,26 @@
+<?php namespace Kris\LaravelFormBuilder\Events;
+
+use Kris\LaravelFormBuilder\Form;
+
+class AfterFormCreation {
+
+    /**
+     * @var $form Form
+     */
+    protected $form;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Form $form) {
+        $this->form = $form;
+    }
+
+    /**
+     * Return the event's form.
+     */
+    public function getForm() {
+        return $this->form;
+    }
+
+}

--- a/src/Kris/LaravelFormBuilder/Events/AfterFormValidation.php
+++ b/src/Kris/LaravelFormBuilder/Events/AfterFormValidation.php
@@ -1,0 +1,53 @@
+<?php namespace Kris\LaravelFormBuilder\Events;
+
+use Illuminate\Contracts\Validation\Validator;
+use Kris\LaravelFormBuilder\Form;
+
+class AfterFormValidation {
+
+    /**
+     * @var $form Form
+     */
+    protected $form;
+
+    /**
+     * @var $validator Validator
+     */
+    protected $validator;
+
+    /**
+     * @var $valid bool
+     */
+    protected $valid;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Form $form, Validator $validator, $valid) {
+        $this->form = $form;
+        $this->validator = $validator;
+        $this->valid = $valid;
+    }
+
+    /**
+     * Return the event's form.
+     */
+    public function getForm() {
+        return $this->form;
+    }
+
+    /**
+     * Return the event's validator.
+     */
+    public function getValidator() {
+        return $this->validator;
+    }
+
+    /**
+     * Return wether the validation passed.
+     */
+    public function isValid() {
+        return $this->valid;
+    }
+
+}

--- a/src/Kris/LaravelFormBuilder/Events/BeforeFormValidation.php
+++ b/src/Kris/LaravelFormBuilder/Events/BeforeFormValidation.php
@@ -1,0 +1,40 @@
+<?php namespace Kris\LaravelFormBuilder\Events;
+
+use Illuminate\Contracts\Validation\Validator;
+use Kris\LaravelFormBuilder\Form;
+
+class BeforeFormValidation {
+
+    /**
+     * @var $form Form
+     */
+    protected $form;
+
+    /**
+     * @var $validator Validator
+     */
+    protected $validator;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(Form $form, Validator $validator) {
+        $this->form = $form;
+        $this->validator = $validator;
+    }
+
+    /**
+     * Return the event's form.
+     */
+    public function getForm() {
+        return $this->form;
+    }
+
+    /**
+     * Return the event's validator.
+     */
+    public function getValidator() {
+        return $this->validator;
+    }
+
+}

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -6,6 +6,7 @@ use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Exception\HttpResponseException;
 use Illuminate\Http\Request;
 use Kris\LaravelFormBuilder\Events\AfterFieldCreation;
+use Kris\LaravelFormBuilder\Events\AfterFormValidation;
 use Kris\LaravelFormBuilder\Events\BeforeFormValidation;
 use Kris\LaravelFormBuilder\Fields\FormField;
 
@@ -1109,7 +1110,11 @@ class Form
             $this->validate();
         }
 
-        return !$this->validator->fails();
+        $isValid = !$this->validator->fails();
+
+        $this->eventDispatcher->fire(new AfterFormValidation($this, $this->validator, $isValid));
+
+        return $isValid;
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1,6 +1,6 @@
 <?php namespace Kris\LaravelFormBuilder;
 
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
@@ -26,7 +26,7 @@ class Form
     protected $model = [];
 
     /**
-     * @var Dispatcher
+     * @var EventDispatcher
      */
     protected $eventDispatcher;
 
@@ -632,10 +632,10 @@ class Form
     /**
      * Set the Event Dispatcher to fire Laravel events
      *
-     * @param Dispatcher $eventDispatcher
+     * @param EventDispatcher $eventDispatcher
      * @return $this
      */
-    public function setEventDispatcher(Dispatcher $eventDispatcher)
+    public function setEventDispatcher(EventDispatcher $eventDispatcher)
     {
         $this->eventDispatcher = $eventDispatcher;
 

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -3,6 +3,8 @@
 use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
+use Kris\LaravelFormBuilder\Events\BeforeFormValidation;
+use Kris\LaravelFormBuilder\Events\AfterFieldCreation;
 use Kris\LaravelFormBuilder\Fields\FormField;
 
 class Form
@@ -158,7 +160,11 @@ class Form
 
         $fieldType = $this->getFieldType($type);
 
-        return new $fieldType($fieldName, $type, $this, $options);
+        $field = new $fieldType($fieldName, $type, $this, $options);
+
+        \Event::fire(new AfterFieldCreation($this, $field));
+
+        return $field;
     }
 
     /**
@@ -1038,6 +1044,8 @@ class Form
 
         $this->validator = $this->validatorFactory->make($this->getRequest()->all(), $rules, $messages);
         $this->validator->setAttributeNames($fieldRules['attributes']);
+
+        \Event::fire(new BeforeFormValidation($this, $this->validator));
 
         return $this->validator;
     }

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1,10 +1,11 @@
 <?php namespace Kris\LaravelFormBuilder;
 
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
-use Kris\LaravelFormBuilder\Events\BeforeFormValidation;
 use Kris\LaravelFormBuilder\Events\AfterFieldCreation;
+use Kris\LaravelFormBuilder\Events\BeforeFormValidation;
 use Kris\LaravelFormBuilder\Fields\FormField;
 
 class Form
@@ -23,6 +24,11 @@ class Form
      * @var mixed
      */
     protected $model = [];
+
+    /**
+     * @var Dispatcher
+     */
+    protected $eventDispatcher;
 
     /**
      * @var FormHelper
@@ -162,7 +168,7 @@ class Form
 
         $field = new $fieldType($fieldName, $type, $this, $options);
 
-        \Event::fire(new AfterFieldCreation($this, $field));
+        $this->eventDispatcher->fire(new AfterFieldCreation($this, $field));
 
         return $field;
     }
@@ -624,6 +630,19 @@ class Form
     }
 
     /**
+     * Set the Event Dispatcher to fire Laravel events
+     *
+     * @param Dispatcher $eventDispatcher
+     * @return $this
+     */
+    public function setEventDispatcher(Dispatcher $eventDispatcher)
+    {
+        $this->eventDispatcher = $eventDispatcher;
+
+        return $this;
+    }
+
+    /**
      * Set the form helper only on first instantiation
      *
      * @param FormHelper $formHelper
@@ -1045,7 +1064,7 @@ class Form
         $this->validator = $this->validatorFactory->make($this->getRequest()->all(), $rules, $messages);
         $this->validator->setAttributeNames($fieldRules['attributes']);
 
-        \Event::fire(new BeforeFormValidation($this, $this->validator));
+        $this->eventDispatcher->fire(new BeforeFormValidation($this, $this->validator));
 
         return $this->validator;
     }

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -91,7 +91,7 @@ class FormBuilder
      */
     public function plain(array $options = [], array $data = [])
     {
-        return $this->container
+        $form = $this->container
             ->make('Kris\LaravelFormBuilder\Form')
             ->addData($data)
             ->setRequest($this->container->make('request'))
@@ -100,5 +100,9 @@ class FormBuilder
             ->setFormBuilder($this)
             ->setValidator($this->container->make('validator'))
             ->setFormOptions($options);
+
+        $this->eventDispatcher->fire(new AfterFormCreation($form));
+
+        return $form;
     }
 }

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -1,6 +1,7 @@
 <?php  namespace Kris\LaravelFormBuilder;
 
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Contracts\Events\Dispatcher;
 use Kris\LaravelFormBuilder\Events\AfterFormCreation;
 
 class FormBuilder
@@ -17,13 +18,19 @@ class FormBuilder
     protected $formHelper;
 
     /**
+     * @var Dispatcher
+     */
+    protected $eventDispatcher;
+
+    /**
      * @param Container  $container
      * @param FormHelper $formHelper
      */
-    public function __construct(Container $container, FormHelper $formHelper)
+    public function __construct(Container $container, FormHelper $formHelper, Dispatcher $eventDispatcher)
     {
         $this->container = $container;
         $this->formHelper = $formHelper;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -47,13 +54,14 @@ class FormBuilder
             ->addData($data)
             ->setRequest($this->container->make('request'))
             ->setFormHelper($this->formHelper)
+            ->setEventDispatcher($this->eventDispatcher)
             ->setFormBuilder($this)
             ->setValidator($this->container->make('validator'))
             ->setFormOptions($options);
 
         $form->buildForm();
 
-        \Event::fire(new AfterFormCreation($form));
+        $this->eventDispatcher->fire(new AfterFormCreation($form));
 
         return $form;
     }

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -1,7 +1,7 @@
 <?php  namespace Kris\LaravelFormBuilder;
 
 use Illuminate\Contracts\Container\Container;
-use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Kris\LaravelFormBuilder\Events\AfterFormCreation;
 
 class FormBuilder
@@ -18,7 +18,7 @@ class FormBuilder
     protected $formHelper;
 
     /**
-     * @var Dispatcher
+     * @var EventDispatcher
      */
     protected $eventDispatcher;
 
@@ -26,7 +26,7 @@ class FormBuilder
      * @param Container  $container
      * @param FormHelper $formHelper
      */
-    public function __construct(Container $container, FormHelper $formHelper, Dispatcher $eventDispatcher)
+    public function __construct(Container $container, FormHelper $formHelper, EventDispatcher $eventDispatcher)
     {
         $this->container = $container;
         $this->formHelper = $formHelper;

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -96,6 +96,7 @@ class FormBuilder
             ->addData($data)
             ->setRequest($this->container->make('request'))
             ->setFormHelper($this->formHelper)
+            ->setEventDispatcher($this->eventDispatcher)
             ->setFormBuilder($this)
             ->setValidator($this->container->make('validator'))
             ->setFormOptions($options);

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -1,6 +1,7 @@
 <?php  namespace Kris\LaravelFormBuilder;
 
 use Illuminate\Contracts\Container\Container;
+use Kris\LaravelFormBuilder\Events\AfterFormCreation;
 
 class FormBuilder
 {
@@ -51,6 +52,8 @@ class FormBuilder
             ->setFormOptions($options);
 
         $form->buildForm();
+
+        \Event::fire(new AfterFormCreation($form));
 
         return $form;
     }

--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -30,7 +30,7 @@ class FormBuilderServiceProvider extends ServiceProvider
 
         $this->app->singleton('laravel-form-builder', function ($app) {
 
-            return new FormBuilder($app, $app['laravel-form-helper'], $app['Illuminate\Contracts\Events\Dispatcher']);
+            return new FormBuilder($app, $app['laravel-form-helper'], $app['events']);
         });
 
         $this->app->alias('laravel-form-builder', 'Kris\LaravelFormBuilder\FormBuilder');

--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -30,7 +30,7 @@ class FormBuilderServiceProvider extends ServiceProvider
 
         $this->app->singleton('laravel-form-builder', function ($app) {
 
-            return new FormBuilder($app, $app['laravel-form-helper']);
+            return new FormBuilder($app, $app['laravel-form-helper'], $app['Illuminate\Contracts\Events\Dispatcher']);
         });
 
         $this->app->alias('laravel-form-builder', 'Kris\LaravelFormBuilder\FormBuilder');

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -96,7 +96,7 @@ namespace {
             $config = $this->config;
             $config['default_namespace'] = 'LaravelFormBuilderTest\Forms';
             $formHelper = new FormHelper($this->view, $this->translator, $config);
-            $formBuilder = new FormBuilder($this->app, $formHelper);
+            $formBuilder = new FormBuilder($this->app, $formHelper, $this->app['Illuminate\Contracts\Events\Dispatcher']);
 
             $formBuilder->create('NamespacedDummyForm');
         }

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -1,6 +1,9 @@
 <?php
+
 namespace {
 
+    use Kris\LaravelFormBuilder\Events\AfterFieldCreation;
+    use Kris\LaravelFormBuilder\Events\AfterFormCreation;
     use Kris\LaravelFormBuilder\Form;
     use Kris\LaravelFormBuilder\FormBuilder;
     use Kris\LaravelFormBuilder\FormHelper;
@@ -43,6 +46,41 @@ namespace {
             $this->assertInstanceOf('Kris\\LaravelFormBuilder\\Form', $customForm);
             $this->assertArrayHasKey('title', $customForm->getFields());
             $this->assertArrayHasKey('body', $customForm->getFields());
+        }
+
+        /** @test */
+        public function it_receives_creation_events()
+        {
+            $events = [];
+
+            $this->eventDispatcher->listen(AfterFormCreation::class, function($event) use (&$events) {
+                $events[] = get_class($event);
+            });
+
+            $this->eventDispatcher->listen(AfterFieldCreation::class, function($event) use (&$events) {
+                $events[] = get_class($event);
+            });
+
+            $form = $this->formBuilder->plain()
+                ->add('name', 'text', ['rules' => ['required', 'min:3']])
+                ->add('alias', 'text');
+
+            $form = $this->formBuilder->create('CustomDummyForm');
+
+            $this->assertEquals(
+                [
+                    // Plain: form first
+                    'Kris\LaravelFormBuilder\Events\AfterFormCreation',
+                    'Kris\LaravelFormBuilder\Events\AfterFieldCreation',
+                    'Kris\LaravelFormBuilder\Events\AfterFieldCreation',
+
+                    // Class: fields first
+                    'Kris\LaravelFormBuilder\Events\AfterFieldCreation',
+                    'Kris\LaravelFormBuilder\Events\AfterFieldCreation',
+                    'Kris\LaravelFormBuilder\Events\AfterFormCreation',
+                ],
+                $events
+            );
         }
 
         /**

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -134,7 +134,7 @@ namespace {
             $config = $this->config;
             $config['default_namespace'] = 'LaravelFormBuilderTest\Forms';
             $formHelper = new FormHelper($this->view, $this->translator, $config);
-            $formBuilder = new FormBuilder($this->app, $formHelper, $this->app['Illuminate\Contracts\Events\Dispatcher']);
+            $formBuilder = new FormBuilder($this->app, $formHelper, $this->app['events']);
 
             $formBuilder->create('NamespacedDummyForm');
         }

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -78,7 +78,7 @@ abstract class FormBuilderTestCase extends TestCase {
         $this->config = include __DIR__.'/../src/config/config.php';
 
         $this->formHelper = new FormHelper($this->view, $this->translator, $this->config);
-        $this->formBuilder = new FormBuilder($this->app, $this->formHelper);
+        $this->formBuilder = new FormBuilder($this->app, $this->formHelper, $this->app['Illuminate\Contracts\Events\Dispatcher']);
 
         $this->plainForm = $this->formBuilder->plain();
     }

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -61,6 +61,11 @@ abstract class FormBuilderTestCase extends TestCase {
     protected $validatorFactory;
 
     /**
+     * @var EventDispatcher
+     */
+    protected $eventDispatcher;
+
+    /**
      * @var Form
      */
     protected $plainForm;
@@ -74,11 +79,12 @@ abstract class FormBuilderTestCase extends TestCase {
         $this->request = $this->app['request'];
         $this->request->setSession($this->app['session.store']);
         $this->validatorFactory = $this->app['validator'];
+        $this->eventDispatcher = $this->app['Illuminate\Contracts\Events\Dispatcher'];
         $this->model = new TestModel();
         $this->config = include __DIR__.'/../src/config/config.php';
 
         $this->formHelper = new FormHelper($this->view, $this->translator, $this->config);
-        $this->formBuilder = new FormBuilder($this->app, $this->formHelper, $this->app['Illuminate\Contracts\Events\Dispatcher']);
+        $this->formBuilder = new FormBuilder($this->app, $this->formHelper, $this->eventDispatcher);
 
         $this->plainForm = $this->formBuilder->plain();
     }

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -79,7 +79,7 @@ abstract class FormBuilderTestCase extends TestCase {
         $this->request = $this->app['request'];
         $this->request->setSession($this->app['session.store']);
         $this->validatorFactory = $this->app['validator'];
-        $this->eventDispatcher = $this->app['Illuminate\Contracts\Events\Dispatcher'];
+        $this->eventDispatcher = $this->app['events'];
         $this->model = new TestModel();
         $this->config = include __DIR__.'/../src/config/config.php';
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Http\Exception\HttpResponseException;
+use Kris\LaravelFormBuilder\Events\AfterFormValidation;
 use Kris\LaravelFormBuilder\Events\BeforeFormValidation;
 use Kris\LaravelFormBuilder\Fields\InputType;
 use Kris\LaravelFormBuilder\Form;
@@ -848,6 +849,10 @@ class FormTest extends FormBuilderTestCase
             $events[] = get_class($event);
         });
 
+        $this->eventDispatcher->listen(AfterFormValidation::class, function($event) use (&$events) {
+            $events[] = get_class($event);
+        });
+
         $this->plainForm->add('name', 'text', ['rules' => ['required', 'min:3']]);
 
         $this->request['name'] = 'Foo Bar';
@@ -855,7 +860,10 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->isValid();
 
         $this->assertEquals(
-            ['Kris\LaravelFormBuilder\Events\BeforeFormValidation'],
+            [
+                'Kris\LaravelFormBuilder\Events\BeforeFormValidation',
+                'Kris\LaravelFormBuilder\Events\AfterFormValidation',
+            ],
             $events
         );
     }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -1,8 +1,9 @@
 <?php
 
+use Kris\LaravelFormBuilder\Events\BeforeFormValidation;
+use Kris\LaravelFormBuilder\Fields\InputType;
 use Kris\LaravelFormBuilder\Form;
 use Kris\LaravelFormBuilder\FormHelper;
-use Kris\LaravelFormBuilder\Fields\InputType;
 
 class FormTest extends FormBuilderTestCase
 {
@@ -759,6 +760,27 @@ class FormTest extends FormBuilderTestCase
 
         $this->assertFalse($this->plainForm->clientValidationEnabled());
         $this->assertFalse($this->plainForm->getField('child_form')->clientValidationEnabled());
+    }
+
+    /** @test */
+    public function it_receives_validation_events()
+    {
+        $events = [];
+
+        $this->eventDispatcher->listen(BeforeFormValidation::class, function($event) use (&$events) {
+            $events[] = get_class($event);
+        });
+
+        $this->plainForm->add('name', 'text', ['rules' => ['required', 'min:3']]);
+
+        $this->request['name'] = 'Foo Bar';
+
+        $this->plainForm->isValid();
+
+        $this->assertEquals(
+            ['Kris\LaravelFormBuilder\Events\BeforeFormValidation'],
+            $events
+        );
     }
 
     /** @test */


### PR DESCRIPTION
Events added:

* AfterFieldCreation (Form, FormField)
* AfterFormCreation (Form)
* BeforeFormValidation (Form, Validator)

I think the names are obvious. With these events, an app or package could do something like:

```
public function onCreateFormField(AfterFieldCreation $event) {
  if ($label = $event->getField()->getOption('label')) {
    $event->getField()->setOption('label', 'x ' . $label);
  }
}

public function onCreateForm(AfterFormCreation $event) {
  $event->getForm()->setFormOption('novalidate', '');
}

public function onValidateForm(BeforeFormValidation $event) {
  $validator = $event->getValidator();
  $validator->after(function() use ($validator) {
    rand(0, 1) and $validator->messages()->add('field', 'Error!');
  });
}
```
