### PR TITLE
Adds attr.append_class option to fields

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -220,6 +220,12 @@ abstract class FormField
 
         $this->options = $helper->mergeOptions($this->options, $options);
 
+        // Append class attribute
+        if ($this->getOption('attr.class_append')) {
+            $appendedClass = $this->getOption('attr.class', '') . ' ' . $this->getOption('attr.class_append');
+            $this->setOption('attr.class', $appendedClass);
+        }
+        
         if ($this->getOption('attr.multiple') && !$this->getOption('tmp.multipleBracesSet')) {
             $this->name = $this->name.'[]';
             $this->setOption('tmp.multipleBracesSet', true);


### PR DESCRIPTION
Adds the ability to use `attr.append_class` to append to the `attr.class` value instead of having to overwrite it. This allows you to use global defaults and not have to hard code them if you just want to add more classes.