### PR TITLE
#244 +FieldsContainerContract, +form_rows(), +form option

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -1,8 +1,9 @@
 <?php  namespace Kris\LaravelFormBuilder\Fields;
 
+use Kris\LaravelFormBuilder\FieldsContainerContract;
 use Kris\LaravelFormBuilder\Form;
 
-class ChildFormType extends ParentType
+class ChildFormType extends ParentType implements FieldsContainerContract
 {
 
     /**
@@ -139,6 +140,40 @@ class ChildFormType extends ParentType
         }
 
         return $this;
+    }
+
+    /**
+     * @param array $options
+     * @param bool  $showLabel
+     * @param bool  $showField
+     * @param bool  $showError
+     * @return string
+     */
+    public function render(array $options = [], $showLabel = true, $showField = true, $showError = true)
+    {
+        $options['form'] = $this;
+        return parent::render($options, $showLabel, $showField, $showError);
+    }
+
+    /**
+     * Wrapper for Form::getField().
+     */
+    public function getField($name) {
+        return $this->form->getField($name);
+    }
+
+    /**
+     * Wrapper for Form::getFields().
+     */
+    public function getFields() {
+        return $this->form->getFields();
+    }
+
+    /**
+     * Wrapper for Form::has().
+     */
+    public function has($name) {
+        return $this->form->has($name);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/FieldsContainerContract.php
+++ b/src/Kris/LaravelFormBuilder/FieldsContainerContract.php
@@ -1,0 +1,20 @@
+<?php namespace Kris\LaravelFormBuilder;
+
+interface FieldsContainerContract {
+
+    /**
+     * @return FormField
+     */
+    public function getField($name);
+
+    /**
+     * @return FormField[]
+     */
+    public function getFields();
+
+    /**
+     * @return bool
+     */
+    public function has($name);
+
+}

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -3,9 +3,10 @@
 use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
+use Kris\LaravelFormBuilder\FieldsContainerContract;
 use Kris\LaravelFormBuilder\Fields\FormField;
 
-class Form
+class Form implements FieldsContainerContract
 {
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kris\LaravelFormBuilder\FieldsContainerContract;
 use Kris\LaravelFormBuilder\Fields\FormField;
 use Kris\LaravelFormBuilder\Form;
 
@@ -53,6 +54,17 @@ if (!function_exists('form_row')) {
     function form_row(FormField $formField, array $options = [])
     {
         return $formField->render($options);
+    }
+
+}
+
+if (!function_exists('form_rows')) {
+
+    function form_rows(FieldsContainerContract $form, array $fields, array $options = [])
+    {
+        return implode(array_map(function($field) use ($form, $options) {
+            return $form->has($field) ? $form->getField($field)->render($options) : '';
+        }, $fields));
     }
 
 }


### PR DESCRIPTION
PR for option 1 of #244 

* Added interface `FieldsContainerContract` to typehint a form-like.
* Added 'form' (the ChildFormType field object) to the options. I'd like it to be in the root vars, not in the options, but FormField has a very strict list of view params.
* Added `form_rows()` to render several form fields at once, by field names instead of multiple `form->getField()->render()`s

I like option 2 better (a `fields.php` tpl), but this is still a good addition IMO.