### PR TITLE
Add ability to append to class attribute for wrapper, label and field

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -220,6 +220,19 @@ abstract class FormField
 
         $this->options = $helper->mergeOptions($this->options, $options);
 
+        foreach (['attr', 'label_attr', 'wrapper'] as $appendable) {
+            // Append values to the 'class' attribute
+            if ($this->getOption("{$appendable}.class_append")) {
+                // Combine the current class attribute with the appends
+                $append = $this->getOption("{$appendable}.class_append");
+                $classAttribute = $this->getOption("{$appendable}.class", '').' '.$append;
+                $this->setOption("{$appendable}.class", $classAttribute);
+
+                // Then remove the class_append option to prevent it from showing up as an attribute in the HTML
+                $this->setOption("{$appendable}.class_append", null);
+            }
+        }
+
         if ($this->getOption('attr.multiple') && !$this->getOption('tmp.multipleBracesSet')) {
             $this->name = $this->name.'[]';
             $this->setOption('tmp.multipleBracesSet', true);

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -77,6 +77,68 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
     }
 
+    /** @test */
+    public function it_appends_to_the_class_attribute_of_the_field()
+    {
+        $options = [
+            'attr' => [
+                'class_append' => 'appended',
+            ],
+        ];
+
+        $text = new InputType('field_name', 'text', $this->plainForm, $options);
+        $renderResult = $text->render();
+
+        $this->assertRegExp('/appended/', $text->getOption('attr.class'));
+
+        $defaultClasses = $this->config['defaults']['field_class'];
+        $this->assertEquals('form-control appended', $text->getOption('attr.class'));
+        
+        $this->assertContains($defaultClasses, $text->getOption('attr.class'));
+        $this->assertNotContains('class_append', $renderResult);
+    }
+
+    /** @test */
+    public function it_appends_to_the_class_attribute_of_the_label()
+    {
+        $options = [
+            'label_attr' => [
+                'class_append' => 'appended',
+            ],
+        ];
+
+        $text = new InputType('field_name', 'text', $this->plainForm, $options);
+        $renderResult = $text->render();
+
+        $this->assertRegExp('/appended/', $text->getOption('label_attr.class'));
+
+        $defaultClasses = $this->config['defaults']['label_class'];
+        $this->assertEquals('control-label appended', $text->getOption('label_attr.class'));
+        
+        $this->assertContains($defaultClasses, $text->getOption('label_attr.class'));
+        $this->assertNotContains('class_append', $renderResult);
+    }
+
+    /** @test */
+    public function it_appends_to_the_class_attribute_of_the_wrapper()
+    {
+        $options = [
+            'wrapper' => [
+                'class_append' => 'appended',
+            ],
+        ];
+
+        $text = new InputType('field_name', 'text', $this->plainForm, $options);
+        $renderResult = $text->render();
+
+        $this->assertRegExp('/appended/', $text->getOption('wrapper.class'));
+
+        $defaultClasses = $this->config['defaults']['wrapper_class'];
+        $this->assertEquals('form-group appended', $text->getOption('wrapper.class'));
+        
+        $this->assertContains($defaultClasses, $text->getOption('wrapper.class'));
+        $this->assertNotContains('class_append', $renderResult);
+    }
 
     /** @test */
     public function it_translates_the_label_if_translation_exists()


### PR DESCRIPTION
Originally proposed by @theshaunwalker in #255 

> Adds the ability to use attr.append_class to append to the attr.class value instead of having to overwrite it. This allows you to use global defaults and not have to hard code them if you just want to add more classes.

I've rewritten it a bit, made sure that `class_append` would not show up as an actual attribute and wrote tests covering appending to wrapper, label and field.