### PR TITLE
Redirect when verification fails

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1056,10 +1056,18 @@ class Form
         return array_merge($fieldRules['rules'], $overrideRules);
     }
 
-    public function redirectIfNotValid()
+    public function redirectIfNotValid($destination = null)
     {
         if (! $this->isValid()) {
-            throw new HttpResponseException(redirect()->back()->withErrors($this->getErrors())->withInput());
+            $response = redirect($destination);
+
+            if (is_null($destination)) {
+                $response = $response->back();
+            }
+
+            $response = $response->withErrors($this->getErrors())->withInput();
+
+            throw new HttpResponseException($response);
         }
     }
 

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1,9 +1,10 @@
 <?php namespace Kris\LaravelFormBuilder;
 
-use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
-use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Http\Request;
 use Kris\LaravelFormBuilder\Fields\FormField;
+use Illuminate\Contracts\Validation\Validator;
+use Illuminate\Http\Exception\HttpResponseException;
+use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 
 class Form
 {
@@ -1053,6 +1054,13 @@ class Form
         $fieldRules = $this->formHelper->mergeFieldsRules($this->fields);
 
         return array_merge($fieldRules['rules'], $overrideRules);
+    }
+
+    public function redirectIfNotValid()
+    {
+        if (! $this->isValid()) {
+            throw new HttpResponseException(redirect()->back()->withErrors($this->getErrors())->withInput());
+        }
     }
 
     /**


### PR DESCRIPTION
Since the following pattern happens for almost every form I'd say, we can create something that is a little less verbose. This code in the controller:

```
$form = magicallyCreateSomeForm();

if (!$form->isValid()) {
    return redirect()->back()->withErrors($form->getErrors())->withInput();
}
```

Would become:

```
$form = magicallyCreateSomeForm();

$form->redirectIfNotValid();
```

Or even this if you don't need really the need the form object after validating:

```
magicallyCreateSomeForm()->redirectIfNotValid();
```

I figured the `Form` class would be a good spot for this, although one could argue that a `redirectIfNotValid($form)` function on the `FormBuilderTrait` might work as well.

A test has been written to ensure a redirect with input and errors is returned when verification fails. I've been using this in one of my projects, and I really like that it cleans up my controller just a little bit more.