### PR TITLE
Fix adding required class to labels when client validation is disabled

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -2,11 +2,11 @@
 
 namespace Kris\LaravelFormBuilder\Fields;
 
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
 use Kris\LaravelFormBuilder\Form;
+use Illuminate\Database\Eloquent\Model;
 use Kris\LaravelFormBuilder\FormHelper;
 use Kris\LaravelFormBuilder\RulesParser;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * Class FormField
@@ -242,20 +242,22 @@ abstract class FormField
             $this->addErrorClass();
         }
 
-        if ($this->parent->clientValidationEnabled()) {
-            if ($this->getOption('required') === true || isset($parsedRules['required'])) {
-                $lblClass = $this->getOption('label_attr.class', '');
-                $requiredClass = $helper->getConfig('defaults.required_class', 'required');
-                if (!str_contains($lblClass, $requiredClass)) {
-                    $lblClass .= ' ' . $requiredClass;
-                    $this->setOption('label_attr.class', $lblClass);
-                    $this->setOption('attr.required', 'required');
-                }
+        if ($this->getOption('required') === true || isset($parsedRules['required'])) {
+            $lblClass = $this->getOption('label_attr.class', '');
+            $requiredClass = $helper->getConfig('defaults.required_class', 'required');
+
+            if (! str_contains($lblClass, $requiredClass)) {
+                $lblClass .= ' '.$requiredClass;
+                $this->setOption('label_attr.class', $lblClass);
             }
 
-            if ($parsedRules) {
-                $attrs = $this->getOption('attr') + $parsedRules;
-                $this->setOption('attr', $attrs);
+            if ($this->parent->clientValidationEnabled()) {
+                $this->setOption('attr.required', 'required');
+
+                if ($parsedRules) {
+                    $attrs = $this->getOption('attr') + $parsedRules;
+                    $this->setOption('attr', $attrs);
+                }
             }
         }
 

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -52,7 +52,7 @@ class FormFieldTest extends FormBuilderTestCase
 
 
     /** @test */
-    public function it_sets_the_required_class_on_the_label_explicitly()
+    public function it_sets_required_as_class_on_the_label_and_attribute_on_the_field_when_setting_required_explicitly()
     {
         $options = [
             'required' => true
@@ -66,7 +66,7 @@ class FormFieldTest extends FormBuilderTestCase
     }
 
     /** @test */
-    public function it_sets_the_required_class_and_label_on_the_label_implicitly()
+    public function it_sets_required_as_class_on_the_label_and_attribute_on_the_field_when_setting_required_via_a_rule()
     {
         $options = [
             'rules' => 'required|min:3'
@@ -80,7 +80,7 @@ class FormFieldTest extends FormBuilderTestCase
     }
 
     /** @test */
-    public function it_adds_the_required_class_when_client_side_validation_is_disabled()
+    public function it_adds_the_required_class_to_the_label_when_client_side_validation_is_disabled()
     {
         $options = [
             'rules' => 'required|min:3'

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -52,7 +52,7 @@ class FormFieldTest extends FormBuilderTestCase
 
 
     /** @test */
-    public function it_sets_the_required_attribute_explicitly()
+    public function it_sets_the_required_class_on_the_label_explicitly()
     {
         $options = [
             'required' => true
@@ -62,10 +62,11 @@ class FormFieldTest extends FormBuilderTestCase
         $hidden->render();
 
         $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
+        $this->assertArrayHasKey('required', $hidden->getOption('attr'));
     }
 
     /** @test */
-    public function it_sets_the_required_attribute_implicitly()
+    public function it_sets_the_required_class_and_label_on_the_label_implicitly()
     {
         $options = [
             'rules' => 'required|min:3'
@@ -75,6 +76,23 @@ class FormFieldTest extends FormBuilderTestCase
         $hidden->render();
 
         $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
+        $this->assertArrayHasKey('required', $hidden->getOption('attr'));
+    }
+
+    /** @test */
+    public function it_adds_the_required_class_when_client_side_validation_is_disabled()
+    {
+        $options = [
+            'rules' => 'required|min:3'
+        ];
+
+        $this->plainForm->setClientValidationEnabled(false);
+
+        $hidden = new InputType('hidden_id', 'hidden', $this->plainForm, $options);
+        $hidden->render();
+
+        $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
+        $this->assertArrayNotHasKey('required', $hidden->getOption('attr'));
     }
 
     /** @test */


### PR DESCRIPTION
The `required` class was not added when client side validation is not enabled. I think it makes sense to add the `required` class to labels even when validation is not enabled. My mistake in #209 😉 

I also changed the test names I wrote back then to be a little more descriptive and added a check for the `required` attribute as well.

If possible, can we create a new version from this soon? I'd love to push this fix to production without having to use my fork as the source for the package. Thanks so much!