### PR TITLE
#244 +form & field vars in field render, +form_rows() helper

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -151,6 +151,15 @@ class ChildFormType extends ParentType
     }
 
     /**
+     * @inheritdoc
+     */
+    protected function getRenderData() {
+        $data = parent::getRenderData();
+        $data['child_form'] = $this->form;
+        return $data;
+    }
+
+    /**
      * @param $method
      * @param $arguments
      *

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -161,11 +161,11 @@ abstract class FormField
             $showError = $this->parent->haveErrorsEnabled();
         }
 
+        $data = $this->getRenderData();
+
         return $this->formHelper->getView()->make(
             $this->getViewTemplate(),
-            [
-                'form' => $this->parent,
-                'field' => $this,
+            $data + [
                 'name' => $this->name,
                 'nameKey' => $this->getNameKey(),
                 'type' => $this->type,
@@ -175,6 +175,15 @@ abstract class FormField
                 'showError' => $showError
             ]
         )->render();
+    }
+
+    /**
+     * Return the extra render data for this form field, passed into the field's template directly.
+     *
+     * @return array
+     */
+    protected function getRenderData() {
+        return [];
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -164,6 +164,8 @@ abstract class FormField
         return $this->formHelper->getView()->make(
             $this->getViewTemplate(),
             [
+                'form' => $this->parent,
+                'field' => $this,
                 'name' => $this->name,
                 'nameKey' => $this->getNameKey(),
                 'type' => $this->type,

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -58,9 +58,8 @@ if (!function_exists('form_row')) {
 }
 
 if (!function_exists('form_rows')) {
-    function form_rows($form, array $fields, array $options = [])
+    function form_rows(Form $form, array $fields, array $options = [])
     {
-        // $form can be a Kris\LaravelFormBuilder\Form or a Kris\LaravelFormBuilder\Fields\ChildFormType
         return implode(array_map(function($field) use ($form, $options) {
             return $form->has($field) ? $form->getField($field)->render($options) : '';
         }, $fields));

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -57,6 +57,16 @@ if (!function_exists('form_row')) {
 
 }
 
+if (!function_exists('form_rows')) {
+    function form_rows($form, array $fields, array $options = [])
+    {
+        // $form can be a Kris\LaravelFormBuilder\Form or a Kris\LaravelFormBuilder\Fields\ChildFormType
+        return implode(array_map(function($field) use ($form, $options) {
+            return $form->has($field) ? $form->getField($field)->render($options) : '';
+        }, $fields));
+    }
+}
+
 if (!function_exists('form_label')) {
 
     function form_label(FormField $formField, array $options = [])


### PR DESCRIPTION
Follow-up of https://github.com/kristijanhusak/laravel-form-builder/pull/256 which was too much.

With these 2 additions, you can make a reusable fields tpl that renders several fields at once:

In `form.php`:

    {{ form_rows(form, ['name', 'age']) }}

In `child_form.php`:

    {{ form_rows(field, ['name', 'age']) }}

because `form` is the form and `field` is the child form, kinda.

I don't like the `$form` argument in `form_rows()` though. It can be a `Form` or a `ChildFormType`, and both work because of `ChildFormType::__call()`, but you can't type hint that...