### PR TITLE
No getFieldValues() for (submit) buttons

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ButtonType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ButtonType.php
@@ -20,4 +20,13 @@ class ButtonType extends FormField
             'attr' => ['type' => $this->type]
         ];
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function getAllAttributes()
+    {
+        // Don't collect input for buttons.
+        return [];
+    }
 }


### PR DESCRIPTION
I forgot one. Submit buttons don't need values. If you `getFieldValues()` with the optional argument to its default (TRUE), it adds NIL values for 'missing' input like a submit button.