### PR TITLE
#244 +fields tpl

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -359,6 +359,25 @@ class Form
     }
 
     /**
+     * Render the entire fields part of the form
+     *
+     * @return string
+     */
+    public function renderFields()
+    {
+        $fields = $this->fields;
+        if (!empty($this->exclude)) {
+            $fields = array_diff_key($fields, array_flip($this->exclude));
+        }
+
+        return $this->formHelper->getView()
+            ->make($this->getFieldsTemplate())
+            ->with('form', $this)
+            ->with('fields', $fields)
+            ->render();
+    }
+
+    /**
      * Render rest of the form
      *
      * @param bool $showFormEnd
@@ -879,6 +898,16 @@ class Form
     protected function getTemplate()
     {
         return $this->getTemplatePrefix() . $this->getFormOption('template', $this->formHelper->getConfig('form'));
+    }
+
+    /**
+     * Get fields template from options if provided, otherwise fallback to config
+     *
+     * @return mixed
+     */
+    protected function getFieldsTemplate()
+    {
+        return $this->getTemplatePrefix() . $this->getFormOption('fields_template', $this->formHelper->getConfig('fields'));
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -25,6 +25,7 @@ return [
     ],
     // Templates
     'form'          => 'laravel-form-builder::form',
+    'fields'        => 'laravel-form-builder::fields',
     'text'          => 'laravel-form-builder::text',
     'textarea'      => 'laravel-form-builder::textarea',
     'button'        => 'laravel-form-builder::button',

--- a/src/views/child_form.php
+++ b/src/views/child_form.php
@@ -9,11 +9,7 @@
 <?php endif; ?>
 
 <?php if ($showField): ?>
-    <?php foreach ((array)$options['children'] as $child): ?>
-        <?php if( ! in_array( $child->getRealName(), (array)$options['exclude']) ) { ?>
-            <?= $child->render() ?>
-        <?php } ?>
-    <?php endforeach; ?>
+    <?= $child_form->renderFields() ?>
 
     <?php include 'help_block.php' ?>
 

--- a/src/views/fields.php
+++ b/src/views/fields.php
@@ -1,0 +1,3 @@
+<?php foreach ($fields as $field): ?>
+	<?= $field->render() ?>
+<?php endforeach; ?>

--- a/src/views/form.php
+++ b/src/views/form.php
@@ -3,11 +3,7 @@
 <?php endif; ?>
 
 <?php if ($showFields): ?>
-    <?php foreach ($fields as $field): ?>
-    	<?php if( ! in_array($field->getName(), $exclude) ) { ?>
-        	<?= $field->render() ?>
-		<?php } ?>
-    <?php endforeach; ?>
+	<?= $form->renderFields(); ?>
 <?php endif; ?>
 
 <?php if ($showEnd): ?>


### PR DESCRIPTION
Functionally this is exactly what I had in mind, but it breaks `$form->renderUntil()` and might break `$child_form->children` and `$options['exclude']`.

It does what I want perfectly though: give a form a fields tpl, and never repeat that display/layout logic anywhere, without overriding anything else:

```
class OrganizationForm extends Form {
    public function buildForm() {
        parent::buildForm();

        $this->setFormOption('fields_template', 'organization/fields');

                // .. add elements here
```

and `CreateOrganizationForm` doesn't care how its child form is rendered:

```
$this->add('organization', 'form', [
    'class' => OrganizationForm::class,
    'label' => 'Organization',
]);
```

because it uses the fields tpl automatically. The only template created is `fields.php`, because both `form.php` and `child_form.php` use `$form->renderFields()` to render it.

But, like I said, it breaks stuff, and I'm not sure how to fix and maintain bc.
