### PR TITLE
Alter field values

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -58,6 +58,14 @@ class ChildFormType extends ParentType
     }
 
     /**
+     * Allow form-specific valid alters
+     */
+    public function alterValid(Form $mainForm, &$isValid)
+    {
+        $this->parent->getFormHelper()->alterValid($this->form, $mainForm, $isValid);
+    }
+
+    /**
      * @return mixed|void
      */
     protected function createChildren()

--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -50,6 +50,14 @@ class ChildFormType extends ParentType
     }
 
     /**
+     * Allow form-specific value alters
+     */
+    public function alterFieldValues(array &$values)
+    {
+        $this->parent->getFormHelper()->alterFieldValues($this->form, $values);
+    }
+
+    /**
      * @return mixed|void
      */
     protected function createChildren()

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1173,7 +1173,17 @@ class Form
             }
         }
 
+        // Allow form-specific value alters
+        $this->formHelper->alterFieldValues($this, $values);
+
         return $values;
+    }
+
+    /**
+     * Optionally mess with this form's $values before it's returned from getFieldValues()
+     */
+    public function alterFieldValues(array &$values)
+    {
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1004,6 +1004,14 @@ class Form
     }
 
     /**
+     * @return Validator
+     */
+    public function getValidator()
+    {
+        return $this->validator;
+    }
+
+    /**
      * Exclude some fields from rendering
      *
      * @return $this
@@ -1132,9 +1140,21 @@ class Form
 
         $isValid = !$this->validator->fails();
 
+        $this->formHelper->alterValid($this, $this, $isValid);
+
         $this->eventDispatcher->fire(new AfterFormValidation($this, $this->validator, $isValid));
 
         return $isValid;
+    }
+
+    /**
+     * Optionally change the validation result, and/or add error messages
+     *
+     * @return void|array
+     */
+    public function alterValid(Form $mainForm, &$isValid)
+    {
+        // return ['name' => ['Some other error about the Name field.']];
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1193,6 +1193,12 @@ class Form
             }
         }
 
+        // If this form is a child form, cherry pick a part
+        if ($prefix = $this->getName()) {
+            $prefix = $this->formHelper->transformToDotSyntax($prefix);
+            $values = Arr::get($values, $prefix);
+        }
+
         // Allow form-specific value alters
         $this->formHelper->alterFieldValues($this, $values);
 

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -1,10 +1,12 @@
 <?php  namespace Kris\LaravelFormBuilder;
 
-use Illuminate\Support\Collection;
-use Symfony\Component\Translation\TranslatorInterface;
-use Illuminate\Database\Eloquent\Model;
-use Kris\LaravelFormBuilder\Fields\FormField;
 use Illuminate\Contracts\View\Factory as View;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
+use Kris\LaravelFormBuilder\Fields\FormField;
+use Kris\LaravelFormBuilder\Form;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class FormHelper
 {
@@ -286,6 +288,28 @@ class FormHelper
         }
 
         return $attributes;
+    }
+
+    /**
+     * Alter a form's values recursively according to its fields
+     *
+     * @return void
+     */
+    public function alterFieldValues(Form $form, array &$values)
+    {
+        // Alter the form itself
+        $form->alterFieldValues($values);
+
+        // Alter the form's child forms recursively
+        foreach ($form->getFields() as $name => $field) {
+            if (method_exists($field, 'alterFieldValues')) {
+                $fullName = $this->transformToDotSyntax($name);
+
+                $subValues = Arr::get($values, $fullName);
+                $field->alterFieldValues($subValues);
+                Arr::set($values, $fullName, $subValues);
+            }
+        }
     }
 
     /**

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -149,6 +149,35 @@ namespace {
                 ->add('body', 'textarea');
         }
     }
+
+    class CustomNesterDummyForm extends Form
+    {
+        public function buildForm()
+        {
+            $this->add('name', 'text');
+
+            $this->add('options', 'choice', [
+                'choices' => ['a' => 'Aaa', 'b' => 'Bbb'],
+                'expanded' => TRUE,
+                'multiple' => TRUE,
+            ]);
+
+            $this->add('subcustom', 'form', [
+                'class' => CustomDummyForm::class,
+            ]);
+        }
+
+        public function alterFieldValues(array &$values)
+        {
+            if (isset($values['name'])) {
+                $values['name'] = strtoupper($values['name']);
+            }
+
+            if (empty($values['options'])) {
+                $values['options'] = ['x'];
+            }
+        }
+    }
 }
 
 namespace LaravelFormBuilderTest\Forms {

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -148,6 +148,15 @@ namespace {
             $this->add('title', 'text')
                 ->add('body', 'textarea');
         }
+
+        public function alterValid(Form $mainForm, &$isValid)
+        {
+            $values = $this->getFieldValues();
+            if ($values['title'] === 'fail on this') {
+                $isValid = false;
+                return ['title' => ['Error on title!']];
+            }
+        }
     }
 
     class CustomNesterDummyForm extends Form

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -98,6 +98,28 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_alters_validity_and_adds_messages()
+    {
+        $customForm = $this->formBuilder->create('CustomNesterDummyForm');
+
+        $this->request['subcustom'] = ['title' => "don't fail on this"];
+
+        $isValid = $customForm->isValid();
+        $this->assertTrue($isValid);
+
+        $this->request['subcustom'] = ['title' => 'fail on this'];
+
+        $isValid = $customForm->isValid();
+        $this->assertFalse($isValid);
+
+        $errors = $customForm->getErrors();
+        $this->assertEquals(
+            ['subcustom.title' => ['Error on title!']],
+            $errors
+        );
+    }
+
+    /** @test */
     public function it_can_automatically_redirect_back_when_failing_verification()
     {
         $this->plainForm

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -272,7 +272,7 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
-    public function it_returns_validated_values()
+    public function it_returns_field_values()
     {
         $this->plainForm
             ->add('name', 'text', [
@@ -320,6 +320,24 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals(
             $check_values,
             $this->plainForm->getFieldValues()
+        );
+    }
+
+    /** @test */
+    public function it_returns_altered_field_values()
+    {
+        $customForm = $this->formBuilder->create('CustomNesterDummyForm');
+
+        $this->request['name'] = 'lower case';
+        $this->request['subcustom'] = ['title' => 'Bar foo', 'body' => 'Foo bar'];
+
+        $this->assertEquals(
+            [
+                'name' => 'LOWER CASE',
+                'options' => ['x'],
+                'subcustom' => ['title' => 'Bar foo', 'body' => 'Foo bar'],
+            ],
+            $customForm->getFieldValues()
         );
     }
 


### PR DESCRIPTION
Added

* `alterFieldValues()` to `Form` to alter that form's values
* `alterFieldValues()` to `FormHelper` to call that alter and recurse through fields
* `alterFieldValues()` to `ChildFormType` to act on and recurse through child forms

Three different functions with the same name... Might not be the best.

With test!

There's still something missing and it might be part of this: form specific validation. If a child form has an image and another form has validation errors, the child form wants to add a validation message to reupload the image. The parent form could do this in `isValid()`, but that's not called for child forms... Ideas?