### PR TITLE
Bugfix in getFieldValues() for CollectionType and RepeatedType

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -61,6 +61,15 @@ class CollectionType extends ParentType
     /**
      * @inheritdoc
      */
+    public function getAllAttributes()
+    {
+        // Collect all children's attributes.
+        return $this->parent->getFormHelper()->mergeAttributes($this->children);
+    }
+
+    /**
+     * @inheritdoc
+     */
     protected function createChildren()
     {
         $this->children = [];

--- a/src/Kris/LaravelFormBuilder/Fields/RepeatedType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/RepeatedType.php
@@ -23,6 +23,15 @@ class RepeatedType extends ParentType
         ];
     }
 
+    /**
+     * @inheritdoc
+     */
+    public function getAllAttributes()
+    {
+        // Collect all children's attributes.
+        return $this->parent->getFormHelper()->mergeAttributes($this->children);
+    }
+
     protected function createChildren()
     {
         $firstName = $this->getRealName();

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -278,7 +278,7 @@ class FormHelper
     /**
      * @return array
      */
-    public function mergeAttributes($fields)
+    public function mergeAttributes(array $fields)
     {
         $attributes = [];
         foreach ($fields as $field) {


### PR DESCRIPTION
More `getFieldValues()` bugs.

* `RepeatedType` skipped the repeated value, because it wasn't in the attributes list
* `CollectionType` added the **entire** data blob for that element, no matter the format, so now it collects children like ChildFormType does

I checked all ParentType components and I think this is it. The rest are radio buttons etc, so they should be included as 1, not per child element.

Aside: I expected CollectionType to validate with `*`: `locations.*.name`, `locations.*.street` etc, but it validates only explicitly present elements, so `locations.0.street`, `locations.1.street` etc. How would you validate a new location added with JS? It's not in the validation list. (And now it's not in the attributes list, so it won't be included in `getFieldValues()`).