### PR TITLE
Dont overwrite $options['real_name']

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -941,7 +941,10 @@ class Form
      */
     protected function setupFieldOptions($name, &$options)
     {
-        $options['real_name'] = $name;
+        // Only set real_name if not already specified
+        if (!isset($options['real_name'])) {
+            $options['real_name'] = $name;
+        }
     }
 
     /**


### PR DESCRIPTION
If you specified 'real_name' in the options when adding a field it didnt matter because it was overriden here.

Just adds a simple check so it doesnt overwrite the 'real_name' value if the user has already set it.