### PR TITLE
Update translator for Laravel 5.4

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Kris\LaravelFormBuilder\Fields\FormField;
 use Kris\LaravelFormBuilder\Form;
-use Symfony\Component\Translation\TranslatorInterface;
+use Illuminate\Translation\Translator;
 
 class FormHelper
 {
@@ -90,7 +90,7 @@ class FormHelper
      * @param TranslatorInterface $translator
      * @param array   $config
      */
-    public function __construct(View $view, TranslatorInterface $translator, array $config = [])
+    public function __construct(View $view, Translator $translator, array $config = [])
     {
         $this->view = $view;
         $this->translator = $translator;


### PR DESCRIPTION
Changed the `Symfony\Component\Translation\TranslatorInterface` to the new `Illuminate\Translation\Translator` so it can work in 5.4.

Related issue:
https://github.com/kristijanhusak/laravel-form-builder/issues/307