### PR TITLE
Improved DocComments, params especially their type, returns, line endings

### DIFF
--- a/src/Kris/LaravelFormBuilder/Console/FormGenerator.php
+++ b/src/Kris/LaravelFormBuilder/Console/FormGenerator.php
@@ -1,12 +1,14 @@
-<?php  namespace Kris\LaravelFormBuilder\Console;
+<?php
+
+namespace Kris\LaravelFormBuilder\Console;
 
 class FormGenerator
 {
 
     /**
-     * Get fields from options and create add methods from it
+     * Get fields from options and create add methods from it.
      *
-     * @param null $fields
+     * @param string|null $fields
      * @return string
      */
     public function getFieldsVariable($fields = null)
@@ -35,9 +37,9 @@ class FormGenerator
     }
 
     /**
-     * Parse fields from string
+     * Parse fields from string.
      *
-     * @param $fields
+     * @param string $fields
      * @return string
      */
     protected function parseFields($fields)
@@ -53,9 +55,9 @@ class FormGenerator
     }
 
     /**
-     * Prepare template for single add field
+     * Prepare template for single add field.
      *
-     * @param      $field
+     * @param string $field
      * @param bool $isLast
      * @return string
      */

--- a/src/Kris/LaravelFormBuilder/Console/FormMakeCommand.php
+++ b/src/Kris/LaravelFormBuilder/Console/FormMakeCommand.php
@@ -1,4 +1,6 @@
-<?php namespace Kris\LaravelFormBuilder\Console;
+<?php
+
+namespace Kris\LaravelFormBuilder\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Filesystem\Filesystem;
@@ -23,7 +25,9 @@ class FormMakeCommand extends GeneratorCommand
     protected $description = 'Create a form builder class';
 
     /**
-     * Type of the file generated
+     * Type of the file generated.
+     *
+     * @var string
      */
     protected $type = 'Form';
 

--- a/src/Kris/LaravelFormBuilder/Events/AfterFieldCreation.php
+++ b/src/Kris/LaravelFormBuilder/Events/AfterFieldCreation.php
@@ -1,22 +1,32 @@
-<?php namespace Kris\LaravelFormBuilder\Events;
+<?php
+
+namespace Kris\LaravelFormBuilder\Events;
 
 use Kris\LaravelFormBuilder\Fields\FormField;
 use Kris\LaravelFormBuilder\Form;
 
-class AfterFieldCreation {
-
+class AfterFieldCreation
+{
     /**
-     * @var $form Form
+     * The form instance.
+     *
+     * @var Form
      */
     protected $form;
 
     /**
-     * @var $field FormField
+     * The field instance.
+     *
+     * @var FormField
      */
     protected $field;
 
     /**
-     * Create a new event instance.
+     * Create a new after field creation instance.
+     *
+     * @param Form $form
+     * @param FormField $field
+     * @return void
      */
     public function __construct(Form $form, FormField $field) {
         $this->form = $form;
@@ -25,6 +35,8 @@ class AfterFieldCreation {
 
     /**
      * Return the event's form.
+     *
+     * @return Form
      */
     public function getForm() {
         return $this->form;
@@ -32,9 +44,10 @@ class AfterFieldCreation {
 
     /**
      * Return the event's field.
+     *
+     * @return FormField
      */
     public function getField() {
         return $this->field;
     }
-
 }

--- a/src/Kris/LaravelFormBuilder/Events/AfterFormCreation.php
+++ b/src/Kris/LaravelFormBuilder/Events/AfterFormCreation.php
@@ -1,16 +1,23 @@
-<?php namespace Kris\LaravelFormBuilder\Events;
+<?php
+
+namespace Kris\LaravelFormBuilder\Events;
 
 use Kris\LaravelFormBuilder\Form;
 
-class AfterFormCreation {
-
+class AfterFormCreation
+{
     /**
-     * @var $form Form
+     * The form instance.
+     *
+     * @var Form
      */
     protected $form;
 
     /**
-     * Create a new event instance.
+     * Create a new after form creation instance.
+     *
+     * @param Form $form
+     * @return void
      */
     public function __construct(Form $form) {
         $this->form = $form;
@@ -18,9 +25,10 @@ class AfterFormCreation {
 
     /**
      * Return the event's form.
+     *
+     * @return Form
      */
     public function getForm() {
         return $this->form;
     }
-
 }

--- a/src/Kris/LaravelFormBuilder/Events/AfterFormValidation.php
+++ b/src/Kris/LaravelFormBuilder/Events/AfterFormValidation.php
@@ -1,29 +1,43 @@
-<?php namespace Kris\LaravelFormBuilder\Events;
+<?php
+
+namespace Kris\LaravelFormBuilder\Events;
 
 use Illuminate\Contracts\Validation\Validator;
 use Kris\LaravelFormBuilder\Form;
 
-class AfterFormValidation {
-
+class AfterFormValidation
+{
     /**
-     * @var $form Form
+     * The form instance.
+     *
+     * @var Form
      */
     protected $form;
 
     /**
-     * @var $validator Validator
+     * The validator instance.
+     *
+     * @var Validator
      */
     protected $validator;
 
     /**
-     * @var $valid bool
+     * Indicates if the form is valid.
+     *
+     * @var bool
      */
     protected $valid;
 
     /**
-     * Create a new event instance.
+     * Create a new after form validation instance.
+     *
+     * @param  Form       $form
+     * @param  Validator  $validator
+     * @param  bool       $valid
+     * @return void
      */
-    public function __construct(Form $form, Validator $validator, $valid) {
+    public function __construct(Form $form, Validator $validator, $valid)
+    {
         $this->form = $form;
         $this->validator = $validator;
         $this->valid = $valid;
@@ -31,22 +45,31 @@ class AfterFormValidation {
 
     /**
      * Return the event's form.
+     *
+     * @return Form
      */
-    public function getForm() {
+    public function getForm()
+    {
         return $this->form;
     }
 
     /**
      * Return the event's validator.
+     *
+     * @return Validator
      */
-    public function getValidator() {
+    public function getValidator()
+    {
         return $this->validator;
     }
 
     /**
-     * Return wether the validation passed.
+     * Return wether the form is valid.
+     *
+     * @return bool
      */
-    public function isValid() {
+    public function isValid()
+    {
         return $this->valid;
     }
 

--- a/src/Kris/LaravelFormBuilder/Events/BeforeFormValidation.php
+++ b/src/Kris/LaravelFormBuilder/Events/BeforeFormValidation.php
@@ -1,40 +1,56 @@
-<?php namespace Kris\LaravelFormBuilder\Events;
+<?php
+
+namespace Kris\LaravelFormBuilder\Events;
 
 use Illuminate\Contracts\Validation\Validator;
 use Kris\LaravelFormBuilder\Form;
 
-class BeforeFormValidation {
-
+class BeforeFormValidation
+{
     /**
-     * @var $form Form
+     * The form instance.
+     *
+     * @var Form
      */
     protected $form;
 
     /**
-     * @var $validator Validator
+     * The validator instance.
+     *
+     * @var Validator
      */
     protected $validator;
 
     /**
      * Create a new event instance.
+     *
+     * @param  Form  $form
+     * @param  Validator  $validator
+     * @return void
      */
-    public function __construct(Form $form, Validator $validator) {
+    public function __construct(Form $form, Validator $validator)
+    {
         $this->form = $form;
         $this->validator = $validator;
     }
 
     /**
-     * Return the event's form.
+     * Get the Form instance of this event.
+     *
+     * @return Form
      */
-    public function getForm() {
+    public function getForm()
+    {
         return $this->form;
     }
 
     /**
-     * Return the event's validator.
+     * Get the Validator instance of this event.
+     *
+     * @return Validator
      */
-    public function getValidator() {
+    public function getValidator()
+    {
         return $this->validator;
     }
-
 }

--- a/src/Kris/LaravelFormBuilder/Facades/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/Facades/FormBuilder.php
@@ -1,9 +1,17 @@
-<?php  namespace Kris\LaravelFormBuilder\Facades;
+<?php
+
+namespace Kris\LaravelFormBuilder\Facades;
 
 use Illuminate\Support\Facades\Facade;
 
-class FormBuilder extends Facade {
+class FormBuilder extends Facade
+{
 
+    /**
+     * Get the registered name of the component.
+     *
+     * @return string
+     */
     public static function getFacadeAccessor()
     {
         return 'laravel-form-builder';

--- a/src/Kris/LaravelFormBuilder/Fields/ButtonGroupType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ButtonGroupType.php
@@ -1,18 +1,29 @@
-<?php namespace  Kris\LaravelFormBuilder\Fields;
+<?php
 
-class ButtonGroupType extends FormField {
-    
+namespace  Kris\LaravelFormBuilder\Fields;
+
+class ButtonGroupType extends FormField
+{
+
+    /**
+     * The path the template.
+     *
+     * @return string
+     */
     protected function getTemplate()
     {
         return 'fields.buttongroup';
     }
-    
+
+    /**
+     * @inheritdoc
+     */
     public function render(array $options = [], $showLabel = true, $showField = true, $showError = true)
     {
         $options['splitted']    = $this->getOption('splitted', false);
         $options['size']        = $this->getOption('size', 'md');
         $options['buttons']     = $this->getOption('buttons', []);
-        
+
         return parent::render($options, $showLabel, $showField, $showError);
     }
 }

--- a/src/Kris/LaravelFormBuilder/Fields/ButtonType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ButtonType.php
@@ -1,4 +1,6 @@
-<?php namespace  Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace  Kris\LaravelFormBuilder\Fields;
 
 class ButtonType extends FormField
 {

--- a/src/Kris/LaravelFormBuilder/Fields/CheckableType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CheckableType.php
@@ -1,4 +1,6 @@
-<?php namespace  Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace  Kris\LaravelFormBuilder\Fields;
 
 class CheckableType extends FormField
 {

--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -1,4 +1,6 @@
-<?php  namespace Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace Kris\LaravelFormBuilder\Fields;
 
 use Kris\LaravelFormBuilder\Form;
 
@@ -50,7 +52,10 @@ class ChildFormType extends ParentType
     }
 
     /**
-     * Allow form-specific value alters
+     * Allow form-specific value alters.
+     *
+     * @param  array $values
+     * @return void
      */
     public function alterFieldValues(array &$values)
     {
@@ -58,7 +63,11 @@ class ChildFormType extends ParentType
     }
 
     /**
-     * Allow form-specific valid alters
+     * Allow form-specific valid alters.
+     *
+     * @param  Form  $mainForm
+     * @param  bool  $isValid
+     * @return void
      */
     public function alterValid(Form $mainForm, &$isValid)
     {
@@ -193,7 +202,7 @@ class ChildFormType extends ParentType
     }
 
     /**
-     * Check if provided value is valid for this type
+     * Check if provided value is valid for this type.
      *
      * @return bool
      */

--- a/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
@@ -1,4 +1,6 @@
-<?php namespace  Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace  Kris\LaravelFormBuilder\Fields;
 
 class ChoiceType extends ParentType
 {
@@ -21,7 +23,7 @@ class ChoiceType extends ParentType
     }
 
     /**
-     * Determine which choice type to use
+     * Determine which choice type to use.
      *
      * @return string
      */
@@ -61,7 +63,9 @@ class ChoiceType extends ParentType
     }
 
     /**
-     * Create children depending on choice type
+     * Create children depending on choice type.
+     *
+     * @return void
      */
     protected function createChildren()
     {
@@ -82,9 +86,11 @@ class ChoiceType extends ParentType
     }
 
     /**
-     * Build checkable children fields from choice type
+     * Build checkable children fields from choice type.
      *
      * @param string $fieldType
+     *
+     * @return void
      */
     protected function buildCheckableChildren($fieldType)
     {
@@ -112,7 +118,7 @@ class ChoiceType extends ParentType
     }
 
     /**
-     * Build select field from choice
+     * Build select field from choice.
      *
      * @param string $fieldType
      */

--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -1,11 +1,13 @@
-<?php  namespace Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace Kris\LaravelFormBuilder\Fields;
 
 use Illuminate\Support\Collection;
 
 class CollectionType extends ParentType
 {
     /**
-     * Contains template for a collection element
+     * Contains template for a collection element.
      *
      * @var FormField
      */
@@ -41,7 +43,7 @@ class CollectionType extends ParentType
     }
 
     /**
-     * Get the prototype object
+     * Get the prototype object.
      *
      * @return FormField
      * @throws \Exception
@@ -88,7 +90,7 @@ class CollectionType extends ParentType
 
         $data = $this->getOption($this->valueProperty, []);
 
-        // If no value is provided, get values from current request
+        // If no value is provided, get values from current request.
         if (count($data) === 0) {
             $data = $currentInput;
         }
@@ -129,7 +131,7 @@ class CollectionType extends ParentType
     }
 
     /**
-     * Set up a single child element for a collection
+     * Set up a single child element for a collection.
      *
      * @param FormField $field
      * @param           $name
@@ -162,9 +164,10 @@ class CollectionType extends ParentType
     }
 
     /**
-     * Generate prototype for regular form field
+     * Generate prototype for regular form field.
      *
      * @param FormField $field
+     * @return void
      */
     protected function generatePrototype(FormField $field)
     {
@@ -184,7 +187,7 @@ class CollectionType extends ParentType
     }
 
     /**
-     * Generate array like prototype name
+     * Generate array like prototype name.
      *
      * @return string
      */
@@ -194,8 +197,10 @@ class CollectionType extends ParentType
     }
 
     /**
-     * Prepare collection for prototype by adding prototype as child
+     * Prepare collection for prototype by adding prototype as child.
+     *
      * @param FormField $field
+     * @return void
      */
     public function preparePrototype(FormField $field)
     {

--- a/src/Kris/LaravelFormBuilder/Fields/EntityType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/EntityType.php
@@ -1,4 +1,6 @@
-<?php namespace  Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace  Kris\LaravelFormBuilder\Fields;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -16,28 +16,28 @@ use Illuminate\Database\Eloquent\Collection;
 abstract class FormField
 {
     /**
-     * Name of the field
+     * Name of the field.
      *
-     * @var
+     * @var string
      */
     protected $name;
 
     /**
-     * Type of the field
+     * Type of the field.
      *
-     * @var
+     * @var string
      */
     protected $type;
 
     /**
-     * All options for the field
+     * All options for the field.
      *
-     * @var
+     * @var array
      */
     protected $options = [];
 
     /**
-     * Is field rendered
+     * Is field rendered.
      *
      * @var bool
      */
@@ -59,14 +59,14 @@ abstract class FormField
     protected $formHelper;
 
     /**
-     * Name of the property for value setting
+     * Name of the property for value setting.
      *
      * @var string
      */
     protected $valueProperty = 'value';
 
     /**
-     * Name of the property for default value
+     * Name of the property for default value.
      *
      * @var string
      */
@@ -74,7 +74,8 @@ abstract class FormField
 
     /**
      * Is default value set?
-     * @var bool
+     *
+     * @var bool|false
      */
     protected $hasDefault = false;
 
@@ -84,10 +85,10 @@ abstract class FormField
     protected $valueClosure = null;
 
     /**
-     * @param             $name
-     * @param             $type
-     * @param Form        $parent
-     * @param array       $options
+     * @param string $name
+     * @param string $type
+     * @param Form $parent
+     * @param array $options
      */
     public function __construct($name, $type, Form $parent, array $options = [])
     {
@@ -100,6 +101,12 @@ abstract class FormField
         $this->setupValue();
     }
 
+
+    /**
+     * Setup the value of the form field.
+     *
+     * @return void
+     */
     protected function setupValue()
     {
         $value = $this->getOption($this->valueProperty);
@@ -117,7 +124,7 @@ abstract class FormField
     }
 
     /**
-     * Get the template, can be config variable or view path
+     * Get the template, can be config variable or view path.
      *
      * @return string
      */
@@ -132,6 +139,8 @@ abstract class FormField
     }
 
     /**
+     * Render the field.
+     *
      * @param array $options
      * @param bool  $showLabel
      * @param bool  $showField
@@ -187,7 +196,7 @@ abstract class FormField
     }
 
     /**
-     * Get the attribute value from the model by name
+     * Get the attribute value from the model by name.
      *
      * @param mixed $model
      * @param string $name
@@ -206,9 +215,9 @@ abstract class FormField
     }
 
     /**
-     * Transform array like syntax to dot syntax
+     * Transform array like syntax to dot syntax.
      *
-     * @param $key
+     * @param string $key
      * @return mixed
      */
     protected function transformKey($key)
@@ -217,7 +226,7 @@ abstract class FormField
     }
 
     /**
-     * Prepare options for rendering
+     * Prepare options for rendering.
      *
      * @param array $options
      * @return array
@@ -286,7 +295,7 @@ abstract class FormField
     }
 
     /**
-     * Get name of the field
+     * Get name of the field.
      *
      * @return string
      */
@@ -296,7 +305,7 @@ abstract class FormField
     }
 
     /**
-     * Set name of the field
+     * Set name of the field.
      *
      * @param string $name
      * @return $this
@@ -309,7 +318,7 @@ abstract class FormField
     }
 
     /**
-     * Get dot notation key for fields
+     * Get dot notation key for fields.
      *
      * @return string
      **/
@@ -319,7 +328,7 @@ abstract class FormField
     }
 
     /**
-     * Get field options
+     * Get field options.
      *
      * @return array
      */
@@ -329,11 +338,10 @@ abstract class FormField
     }
 
     /**
-     * Get single option from options array. Can be used with dot notation ('attr.class')
+     * Get single option from options array. Can be used with dot notation ('attr.class').
      *
-     * @param        $option
-     * @param mixed  $default
-     *
+     * @param string $option
+     * @param mixed|null $default
      * @return mixed
      */
     public function getOption($option, $default = null)
@@ -342,7 +350,7 @@ abstract class FormField
     }
 
     /**
-     * Set field options
+     * Set field options.
      *
      * @param array $options
      * @return $this
@@ -355,7 +363,7 @@ abstract class FormField
     }
 
     /**
-     * Set single option on the field
+     * Set single option on the field.
      *
      * @param string $name
      * @param mixed $value
@@ -369,7 +377,7 @@ abstract class FormField
     }
 
     /**
-     * Get the type of the field
+     * Get the type of the field.
      *
      * @return string
      */
@@ -379,7 +387,7 @@ abstract class FormField
     }
 
     /**
-     * Set type of the field
+     * Set type of the field.
      *
      * @param mixed $type
      * @return $this
@@ -402,7 +410,7 @@ abstract class FormField
     }
 
     /**
-     * Check if the field is rendered
+     * Check if the field is rendered.
      *
      * @return bool
      */
@@ -412,7 +420,7 @@ abstract class FormField
     }
 
     /**
-     * Default options for field
+     * Default options for field.
      *
      * @return array
      */
@@ -422,7 +430,7 @@ abstract class FormField
     }
 
     /**
-     * Defaults used across all fields
+     * Defaults used across all fields.
      *
      * @return array
      */
@@ -447,7 +455,7 @@ abstract class FormField
     }
 
     /**
-     * Get real name of the field without form namespace
+     * Get real name of the field without form namespace.
      *
      * @return string
      */
@@ -482,7 +490,9 @@ abstract class FormField
     }
 
     /**
-     * Set the template property on the object
+     * Set the template property on the object.
+     *
+     * @return void
      */
     private function setTemplate()
     {
@@ -490,7 +500,9 @@ abstract class FormField
     }
 
     /**
-     * Add error class to wrapper if validation errors exist
+     * Add error class to wrapper if validation errors exist.
+     *
+     * @return void
      */
     protected function addErrorClass()
     {
@@ -509,7 +521,7 @@ abstract class FormField
 
 
     /**
-     * Merge all defaults with field specific defaults and set template if passed
+     * Merge all defaults with field specific defaults and set template if passed.
      *
      * @param array $options
      */
@@ -549,6 +561,11 @@ abstract class FormField
         return $defaults;
     }
 
+    /**
+     * Setup the label for the form field.
+     *
+     * @return void
+     */
     protected function setupLabel()
     {
         if ($this->getOption('label') !== null) {
@@ -565,7 +582,7 @@ abstract class FormField
     }
 
     /**
-     * Check if fields needs label
+     * Check if fields needs label.
      *
      * @return bool
      */
@@ -582,7 +599,7 @@ abstract class FormField
     }
 
     /**
-     * Disable field
+     * Disable field.
      *
      * @return $this
      */
@@ -594,7 +611,7 @@ abstract class FormField
     }
 
     /**
-     * Enable field
+     * Enable field.
      *
      * @return $this
      */
@@ -606,7 +623,7 @@ abstract class FormField
     }
 
     /**
-     * Get validation rules for a field if any with label for attributes
+     * Get validation rules for a field if any with label for attributes.
      *
      * @return array|null
      */
@@ -648,7 +665,7 @@ abstract class FormField
     }
 
     /**
-     * Get value property
+     * Get value property.
      *
      * @param mixed|null $default
      * @return mixed
@@ -659,7 +676,7 @@ abstract class FormField
     }
 
     /**
-     * Get default value property
+     * Get default value property.
      *
      * @param mixed|null $default
      * @return mixed
@@ -670,7 +687,7 @@ abstract class FormField
     }
 
     /**
-     * Check if provided value is valid for this type
+     * Check if provided value is valid for this type.
      *
      * @return bool
      */

--- a/src/Kris/LaravelFormBuilder/Fields/InputType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/InputType.php
@@ -1,4 +1,6 @@
-<?php namespace  Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace  Kris\LaravelFormBuilder\Fields;
 
 class InputType extends FormField
 {

--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -1,4 +1,6 @@
-<?php  namespace Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace Kris\LaravelFormBuilder\Fields;
 
 use Kris\LaravelFormBuilder\Form;
 
@@ -11,7 +13,7 @@ abstract class ParentType extends FormField
     protected $children;
 
     /**
-     * Populate children array
+     * Populate children array.
      *
      * @return mixed
      */
@@ -22,12 +24,13 @@ abstract class ParentType extends FormField
      * @param       $type
      * @param Form  $parent
      * @param array $options
+     * @return void
      */
     public function __construct($name, $type, Form $parent, array $options = [])
     {
         parent::__construct($name, $type, $parent, $options);
         // If there is default value provided and  setValue was not triggered
-        // in the parent call, make sure we generate child elements
+        // in the parent call, make sure we generate child elements.
         if ($this->hasDefault) {
             $this->createChildren();
         }
@@ -48,11 +51,7 @@ abstract class ParentType extends FormField
     }
 
     /**
-     * @param array $options
-     * @param bool  $showLabel
-     * @param bool  $showField
-     * @param bool  $showError
-     * @return string
+     * {inheritdoc}
      */
     public function render(array $options = [], $showLabel = true, $showField = true, $showError = true)
     {
@@ -61,7 +60,7 @@ abstract class ParentType extends FormField
     }
 
     /**
-     * Get all children of the choice field
+     * Get all children of the choice field.
      *
      * @return mixed
      */
@@ -71,7 +70,7 @@ abstract class ParentType extends FormField
     }
 
     /**
-     * Get a child of the choice field
+     * Get a child of the choice field.
      *
      * @return mixed
      */
@@ -81,7 +80,7 @@ abstract class ParentType extends FormField
     }
 
     /**
-     * Remove child
+     * Remove child.
      *
      * @return $this
      */
@@ -109,9 +108,9 @@ abstract class ParentType extends FormField
     }
 
     /**
-     * Get child dynamically
+     * Get child dynamically.
      *
-     * @param $name
+     * @param string $name
      * @return FormField
      */
     public function __get($name)
@@ -120,7 +119,9 @@ abstract class ParentType extends FormField
     }
 
     /**
-     * Check if field has type property and if it's file add enctype/multipart to form
+     * Check if field has type property and if it's file add enctype/multipart to form.
+     *
+     * @return void
      */
     protected function checkIfFileType()
     {

--- a/src/Kris/LaravelFormBuilder/Fields/RepeatedType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/RepeatedType.php
@@ -1,10 +1,12 @@
-<?php  namespace Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace Kris\LaravelFormBuilder\Fields;
 
 class RepeatedType extends ParentType
 {
 
     /**
-     * Get the template, can be config variable or view path
+     * Get the template, can be config variable or view path.
      *
      * @return string
      */
@@ -13,6 +15,9 @@ class RepeatedType extends ParentType
         return 'repeated';
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function getDefaults()
     {
         return [
@@ -32,6 +37,9 @@ class RepeatedType extends ParentType
         return $this->parent->getFormHelper()->mergeAttributes($this->children);
     }
 
+    /**
+     * @inheritdoc
+     */
     protected function createChildren()
     {
         $firstName = $this->getRealName();

--- a/src/Kris/LaravelFormBuilder/Fields/SelectType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/SelectType.php
@@ -1,15 +1,28 @@
-<?php namespace  Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace  Kris\LaravelFormBuilder\Fields;
 
 class SelectType extends FormField
 {
 
+    /**
+     * The name of the property that holds the value.
+     *
+     * @var string
+     */
     protected $valueProperty = 'selected';
 
+     /**
+     * @inheritdoc
+     */
     protected function getTemplate()
     {
         return 'select';
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getDefaults()
     {
         return [

--- a/src/Kris/LaravelFormBuilder/Fields/StaticType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/StaticType.php
@@ -1,7 +1,12 @@
-<?php namespace  Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace  Kris\LaravelFormBuilder\Fields;
 
 class StaticType extends FormField
 {
+    /**
+     * @inheritdoc
+     */
     public function render(array $options = [], $showLabel = true, $showField = true, $showError = false)
     {
         $this->setupStaticOptions($options);
@@ -9,7 +14,10 @@ class StaticType extends FormField
     }
 
     /**
-     * Setup static field options
+     * Setup static field options.
+     *
+     * @param array $options
+     * @return void
      */
     private function setupStaticOptions(&$options)
     {

--- a/src/Kris/LaravelFormBuilder/Fields/TextareaType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/TextareaType.php
@@ -1,4 +1,6 @@
-<?php namespace Kris\LaravelFormBuilder\Fields;
+<?php
+
+namespace Kris\LaravelFormBuilder\Fields;
 
 class TextareaType extends FormField
 {

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1,4 +1,6 @@
-<?php namespace Kris\LaravelFormBuilder;
+<?php
+
+namespace Kris\LaravelFormBuilder;
 
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
@@ -15,14 +17,14 @@ class Form
 {
 
     /**
-     * All fields that are added
+     * All fields that are added.
      *
      * @var array
      */
     protected $fields = [];
 
     /**
-     * Model to use
+     * Model to use.
      *
      * @var mixed
      */
@@ -39,7 +41,7 @@ class Form
     protected $formHelper;
 
     /**
-     * Form options
+     * Form options.
      *
      * @var array
      */
@@ -49,28 +51,28 @@ class Form
     ];
 
     /**
-     * Additional data which can be used to build fields
+     * Additional data which can be used to build fields.
      *
      * @var array
      */
     protected $data = [];
 
     /**
-     * Should errors for each field be shown when called form($form) or form_rest($form) ?
+     * Wether errors for each field should be shown when calling form($form) or form_rest($form).
      *
      * @var bool
      */
     protected $showFieldErrors = true;
 
     /**
-     * Enable html5 validation
+     * Enable html5 validation.
      *
      * @var bool
      */
     protected $clientValidationEnabled = true;
 
     /**
-     * Name of the parent form if any
+     * Name of the parent form if any.
      *
      * @var string|null
      */
@@ -97,14 +99,14 @@ class Form
     protected $request;
 
     /**
-     * List of fields to not render
+     * List of fields to not render.
      *
      * @var array
      **/
     protected $exclude = [];
 
     /**
-     * Are form being rebuilt?
+     * Wether the form is beign rebuild.
      *
      * @var bool
      */
@@ -121,7 +123,7 @@ class Form
     protected $languageName;
 
     /**
-     * Build the form
+     * Build the form.
      *
      * @return mixed
      */
@@ -130,7 +132,7 @@ class Form
     }
 
     /**
-     * Rebuild the form from scratch
+     * Rebuild the form from scratch.
      *
      * @return $this
      */
@@ -154,7 +156,7 @@ class Form
     }
 
     /**
-     * Create the FormField object
+     * Create the FormField object.
      *
      * @param string $name
      * @param string $type
@@ -177,7 +179,7 @@ class Form
     }
 
     /**
-     * Create a new field and add it to the form
+     * Create a new field and add it to the form.
      *
      * @param string $name
      * @param string $type
@@ -199,7 +201,7 @@ class Form
     }
 
     /**
-     * Add a FormField to the form's fields
+     * Add a FormField to the form's fields.
      *
      * @param FormField $field
      * @return $this
@@ -221,10 +223,10 @@ class Form
     }
 
     /**
-     * Add field before another field
+     * Add field before another field.
      *
-     * @param string  $name         Name of the field before which new field is added
-     * @param string  $fieldName    Field name which will be added
+     * @param string  $name         Name of the field before which new field is added.
+     * @param string  $fieldName    Field name which will be added.
      * @param string  $type
      * @param array   $options
      * @param boolean $modify
@@ -247,9 +249,10 @@ class Form
     }
 
     /**
-     * Add field before another field
-     * @param string  $name         Name of the field after which new field is added
-     * @param string  $fieldName    Field name which will be added
+     * Add field before another field.
+     *
+     * @param string  $name         Name of the field after which new field is added.
+     * @param string  $fieldName    Field name which will be added.
      * @param string  $type
      * @param array   $options
      * @param boolean $modify
@@ -272,8 +275,9 @@ class Form
     }
 
     /**
-     * Take another form and add it's fields directly to this form
-     * @param mixed   $class        Form to merge
+     * Take another form and add it's fields directly to this form.
+     *
+     * @param mixed   $class        Form to merge.
      * @param array   $options
      * @param boolean $modify
      * @return $this
@@ -282,13 +286,13 @@ class Form
     {
         $options['class'] = $class;
 
-        // If we pass a ready made form just extract the fields
+        // If we pass a ready made form just extract the fields.
         if ($class instanceof Form) {
             $fields = $class->getFields();
         } elseif ($class instanceof Fields\ChildFormType) {
             $fields = $class->getForm()->getFields();
         } elseif (is_string($class)) {
-            // If its a string of a class make it the usual way
+            // If its a string of a class make it the usual way.
             $options['model'] = $this->model;
             $options['name'] = $this->name;
 
@@ -308,7 +312,7 @@ class Form
     }
 
     /**
-     * Remove field with specified name from the form
+     * Remove field with specified name from the form.
      *
      * @param $name
      * @return $this
@@ -323,9 +327,9 @@ class Form
     }
 
     /**
-     * Modify existing field. If it doesn't exist, it is added to form
+     * Modify existing field. If it doesn't exist, it is added to form.
      *
-     * @param        $name
+     * @param string $name
      * @param string $type
      * @param array  $options
      * @param bool   $overwriteOptions
@@ -333,7 +337,7 @@ class Form
      */
     public function modify($name, $type = 'text', array $options = [], $overwriteOptions = false)
     {
-        // If we don't want to overwrite options, we merge them with old options
+        // If we don't want to overwrite options, we merge them with old options.
         if ($overwriteOptions === false && $this->has($name)) {
             $options = $this->formHelper->mergeOptions(
                 $this->getField($name)->getOptions(),
@@ -345,7 +349,7 @@ class Form
     }
 
     /**
-     * Render full form
+     * Render full form.
      *
      * @param array $options
      * @param bool  $showStart
@@ -359,7 +363,7 @@ class Form
     }
 
     /**
-     * Render rest of the form
+     * Render rest of the form.
      *
      * @param bool $showFormEnd
      * @param bool $showFields
@@ -373,7 +377,7 @@ class Form
     }
 
     /**
-     * Renders the rest of the form up until the specified field name
+     * Renders the rest of the form up until the specified field name.
      *
      * @param string $field_name
      * @param bool   $showFormEnd
@@ -402,9 +406,9 @@ class Form
     }
 
     /**
-     * Get single field instance from form object
+     * Get single field instance from form object.
      *
-     * @param $name
+     * @param string $name
      * @return FormField
      */
     public function getField($name)
@@ -417,9 +421,9 @@ class Form
     }
 
     /**
-     * Check if form has field
+     * Check if form has field.
      *
-     * @param $name
+     * @param string $name
      * @return bool
      */
     public function has($name)
@@ -428,7 +432,7 @@ class Form
     }
 
     /**
-     * Get all form options
+     * Get all form options.
      *
      * @return array
      */
@@ -438,10 +442,10 @@ class Form
     }
 
     /**
-     * Get single form option
+     * Get single form option.
      *
      * @param string $option
-     * @param $default
+     * @param mixed|null $default
      * @return mixed
      */
     public function getFormOption($option, $default = null)
@@ -450,7 +454,7 @@ class Form
     }
 
     /**
-     * Set single form option on form
+     * Set single form option on form.
      *
      * @param string $option
      * @param mixed $value
@@ -465,12 +469,12 @@ class Form
     }
 
     /**
-     * Set form options
+     * Set form options.
      *
      * @param array $formOptions
      * @return $this
      */
-    public function setFormOptions($formOptions)
+    public function setFormOptions(array $formOptions)
     {
         $this->formOptions = $this->formHelper->mergeOptions($this->formOptions, $formOptions);
         $this->checkIfNamedForm();
@@ -485,10 +489,10 @@ class Form
     }
 
     /**
-     * Get an option from provided options and call method with that value
+     * Get an option from provided options and call method with that value.
      *
-     * @param $name
-     * @param $method
+     * @param string $name
+     * @param string $method
      */
     protected function pullFromOptions($name, $method)
     {
@@ -498,7 +502,7 @@ class Form
     }
 
     /**
-     * Get form http method
+     * Get form http method.
      *
      * @return string
      */
@@ -508,7 +512,7 @@ class Form
     }
 
     /**
-     * Set form http method
+     * Set form http method.
      *
      * @param string $method
      * @return $this
@@ -521,7 +525,7 @@ class Form
     }
 
     /**
-     * Get form action url
+     * Get form action url.
      *
      * @return string
      */
@@ -531,7 +535,7 @@ class Form
     }
 
     /**
-     * Set form action url
+     * Set form action url.
      *
      * @param string $url
      * @return $this
@@ -544,6 +548,8 @@ class Form
     }
 
     /**
+     * Returns the name of the form.
+     *
      * @return string|null
      */
     public function getName()
@@ -552,9 +558,10 @@ class Form
     }
 
     /**
+     * Set the name of the form.
+     *
      * @param string $name
      * @param bool $rebuild
-     *
      * @return $this
      */
     public function setName($name, $rebuild = true)
@@ -569,7 +576,7 @@ class Form
     }
 
     /**
-     * Get model that is bind to form object
+     * Get model that is bind to form object.
      *
      * @return mixed
      */
@@ -579,7 +586,7 @@ class Form
     }
 
     /**
-     * Set model to form object
+     * Set model to form object.
      *
      * @param mixed $model
      * @return $this
@@ -597,7 +604,8 @@ class Form
     }
 
     /**
-     * Setup model for form, add namespace if needed for child forms
+     * Setup model for form, add namespace if needed for child forms.
+     *
      * @return $this
      */
     protected function setupModel($model)
@@ -610,7 +618,7 @@ class Form
     }
 
     /**
-     * Get all fields
+     * Get all fields.
      *
      * @return FormField[]
      */
@@ -620,9 +628,9 @@ class Form
     }
 
     /**
-     * Get field dynamically
+     * Get field dynamically.
      *
-     * @param $name
+     * @param string $name
      * @return FormField
      */
     public function __get($name)
@@ -633,8 +641,9 @@ class Form
     }
 
     /**
-     * Check if field exists when fetched using magic methods
-     * @param $name
+     * Check if field exists when fetched using magic methods.
+     *
+     * @param string $name
      * @return bool
      */
     public function __isset($name)
@@ -643,7 +652,7 @@ class Form
     }
 
     /**
-     * Set the Event Dispatcher to fire Laravel events
+     * Set the Event Dispatcher to fire Laravel events.
      *
      * @param EventDispatcher $eventDispatcher
      * @return $this
@@ -656,7 +665,7 @@ class Form
     }
 
     /**
-     * Set the form helper only on first instantiation
+     * Set the form helper only on first instantiation.
      *
      * @param FormHelper $formHelper
      * @return $this
@@ -669,7 +678,7 @@ class Form
     }
 
     /**
-     * Get form helper
+     * Get form helper.
      *
      * @return FormHelper
      */
@@ -679,7 +688,7 @@ class Form
     }
 
     /**
-     * Add custom field
+     * Add custom field.
      *
      * @param $name
      * @param $class
@@ -690,7 +699,7 @@ class Form
     }
 
     /**
-     * Should form errors be shown under every field ?
+     * Returns wether form errors should be shown under every field.
      *
      * @return bool
      */
@@ -723,7 +732,7 @@ class Form
     }
 
     /**
-     * Enable/disable client validation
+     * Enable/disable client validation.
      *
      * @param boolean $enable
      * @return $this
@@ -736,10 +745,10 @@ class Form
     }
 
     /**
-     * Add any aditional data that field needs (ex. array of choices)
+     * Add any aditional data that field needs (ex. array of choices).
      *
      * @deprecated deprecated since 1.6.20, will be removed in 1.7 - use 3rd param on create, or 2nd on plain method to pass data
-     * will be switched to protected in 1.7
+     * will be switched to protected in 1.7.
      * @param string $name
      * @param mixed $data
      */
@@ -749,7 +758,7 @@ class Form
     }
 
     /**
-     * Get single additional data
+     * Get single additional data.
      *
      * @param string $name
      * @param null   $default
@@ -765,10 +774,10 @@ class Form
     }
 
     /**
-     * Add multiple peices of data at once
+     * Add multiple peices of data at once.
      *
      * @deprecated deprecated since 1.6.12, will be removed in 1.7 - use 3rd param on create, or 2nd on plain method to pass data
-     * will be switched to protected in 1.7
+     * will be switched to protected in 1.7.
      * @param $data
      * @return $this
      **/
@@ -782,7 +791,7 @@ class Form
     }
 
     /**
-     * Get current request
+     * Get current request.
      *
      * @return \Illuminate\Http\Request
      */
@@ -792,7 +801,7 @@ class Form
     }
 
     /**
-     * Set request on form
+     * Set request on form.
      *
      * @param Request $request
      * @return $this
@@ -805,7 +814,7 @@ class Form
     }
 
     /**
-     * Get template prefix that is prepended to all template paths
+     * Get template prefix that is prepended to all template paths.
      *
      * @return string
      */
@@ -819,7 +828,7 @@ class Form
     }
 
     /**
-     * Set a template prefix for the form and its fields
+     * Set a template prefix for the form and its fields.
      *
      * @param string $prefix
      * @return $this
@@ -832,7 +841,7 @@ class Form
     }
 
     /**
-     * Get the language name
+     * Get the language name.
      *
      * @return string
      */
@@ -842,7 +851,7 @@ class Form
     }
 
     /**
-     * Set a language name, used as prefix for translated strings
+     * Set a language name, used as prefix for translated strings.
      *
      * @param string $prefix
      * @return $this
@@ -855,13 +864,13 @@ class Form
     }
 
     /**
-     * Render the form
+     * Render the form.
      *
-     * @param $options
-     * @param $fields
-     * @param boolean $showStart
-     * @param boolean $showFields
-     * @param boolean $showEnd
+     * @param array $options
+     * @param string $fields
+     * @param bool $showStart
+     * @param bool $showFields
+     * @param bool $showEnd
      * @return string
      */
     protected function render($options, $fields, $showStart, $showFields, $showEnd)
@@ -882,7 +891,7 @@ class Form
     }
 
     /**
-     * Get template from options if provided, otherwise fallback to config
+     * Get template from options if provided, otherwise fallback to config.
      *
      * @return mixed
      */
@@ -892,7 +901,7 @@ class Form
     }
 
     /**
-     * Get all fields that are not rendered
+     * Get all fields that are not rendered.
      *
      * @return array
      */
@@ -911,9 +920,11 @@ class Form
     }
 
     /**
-     * Prevent adding fields with same name
+     * Prevent adding fields with same name.
      *
      * @param string $name
+     * @throws \InvalidArgumentException
+     * @return void
      */
     protected function preventDuplicate($name)
     {
@@ -923,6 +934,8 @@ class Form
     }
 
     /**
+     * Returns and checks the type of the field.
+     *
      * @param string $type
      * @return string
      */
@@ -934,7 +947,9 @@ class Form
     }
 
     /**
-     * Check if form is named form
+     * Check if form is named form.
+     *
+     * @return void
      */
     protected function checkIfNamedForm()
     {
@@ -944,7 +959,7 @@ class Form
     }
 
     /**
-     * Set up options on single field depending on form options
+     * Set up options on single field depending on form options.
      *
      * @param string $name
      * @param $options
@@ -955,8 +970,8 @@ class Form
     }
 
     /**
-     * Set namespace to model if form is named so the data is bound properly
-     * Returns true if model is changed, otherwise false
+     * Set namespace to model if form is named so the data is bound properly.
+     * Returns true if model is changed, otherwise false.
      *
      * @return bool
      */
@@ -982,7 +997,7 @@ class Form
 
 
     /**
-     * Set form builder instance on helper so we can use it later
+     * Set form builder instance on helper so we can use it later.
      *
      * @param FormBuilder $formBuilder
      * @return $this
@@ -995,6 +1010,8 @@ class Form
     }
 
     /**
+     * Returns the instance of the FormBuilder.
+     *
      * @return FormBuilder
      */
     public function getFormBuilder()
@@ -1003,6 +1020,8 @@ class Form
     }
 
     /**
+     * Set the Validator instance on this so we can use it later.
+     *
      * @param ValidatorFactory $validator
      * @return $this
      */
@@ -1014,6 +1033,8 @@ class Form
     }
 
     /**
+     * Returns the validator instance.
+     *
      * @return Validator
      */
     public function getValidator()
@@ -1022,7 +1043,7 @@ class Form
     }
 
     /**
-     * Exclude some fields from rendering
+     * Exclude some fields from rendering.
      *
      * @return $this
      */
@@ -1035,7 +1056,7 @@ class Form
 
 
     /**
-     * If form is named form, modify names to be contained in single key (parent[child_field_name])
+     * If form is named form, modify names to be contained in single key (parent[child_field_name]).
      *
      * @param string $name
      * @return string
@@ -1059,7 +1080,7 @@ class Form
     }
 
     /**
-     * Disable all fields in a form
+     * Disable all fields in a form.
      */
     public function disableFields()
     {
@@ -1069,7 +1090,7 @@ class Form
     }
 
     /**
-     * Enable all fields in a form
+     * Enable all fields in a form.
      */
     public function enableFields()
     {
@@ -1079,7 +1100,7 @@ class Form
     }
 
     /**
-     * Validate the form
+     * Validate the form.
      *
      * @param array $validationRules
      * @param array $messages
@@ -1100,7 +1121,7 @@ class Form
     }
 
     /**
-     * Get validatdion rules for the form
+     * Get validation rules for the form.
      *
      * @param array $overrideRules
      * @return array
@@ -1112,6 +1133,12 @@ class Form
         return array_merge($fieldRules['rules'], $overrideRules);
     }
 
+    /**
+     * Redirects to a destination when form is invalid.
+     *
+     * @param  string|null $destination The target url.
+     * @return HttpResponseException
+     */
     public function redirectIfNotValid($destination = null)
     {
         if (! $this->isValid()) {
@@ -1138,7 +1165,7 @@ class Form
     }
 
     /**
-     * Check if the form is valid
+     * Check if the form is valid.
      *
      * @return bool
      */
@@ -1158,8 +1185,10 @@ class Form
     }
 
     /**
-     * Optionally change the validation result, and/or add error messages
+     * Optionally change the validation result, and/or add error messages.
      *
+     * @param Form $mainForm
+     * @param bool $isValid
      * @return void|array
      */
     public function alterValid(Form $mainForm, &$isValid)
@@ -1168,7 +1197,7 @@ class Form
     }
 
     /**
-     * Get validation errors
+     * Get validation errors.
      *
      * @return array
      */
@@ -1189,6 +1218,7 @@ class Form
     /**
      * Get all Request values from all fields, and nothing else.
      *
+     * @param bool $with_nulls
      * @return array
      */
     public function getFieldValues($with_nulls = true)
@@ -1216,17 +1246,21 @@ class Form
     }
 
     /**
-     * Optionally mess with this form's $values before it's returned from getFieldValues()
+     * Optionally mess with this form's $values before it's returned from getFieldValues().
+     *
+     * @param array $values
+     * @return void
      */
     public function alterFieldValues(array &$values)
     {
     }
 
     /**
-     * Throw an exception indicating a field does not exist on the class
+     * Throw an exception indicating a field does not exist on the class.
      *
      * @param string $name
      * @throws \InvalidArgumentException
+     * @return void
      */
     protected function fieldDoesNotExist($name)
     {

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -229,7 +229,7 @@ class Form
      * @param string  $fieldName    Field name which will be added.
      * @param string  $type
      * @param array   $options
-     * @param boolean $modify
+     * @param bool $modify
      * @return $this
      */
     public function addBefore($name, $fieldName, $type = 'text', $options = [], $modify = false)
@@ -255,7 +255,7 @@ class Form
      * @param string  $fieldName    Field name which will be added.
      * @param string  $type
      * @param array   $options
-     * @param boolean $modify
+     * @param bool $modify
      * @return $this
      */
     public function addAfter($name, $fieldName, $type = 'text', $options = [], $modify = false)
@@ -711,12 +711,12 @@ class Form
     /**
      * Enable or disable showing errors under fields
      *
-     * @param boolean $enabled
+     * @param bool $enabled
      * @return $this
      */
     public function setErrorsEnabled($enabled)
     {
-        $this->showFieldErrors = (boolean) $enabled;
+        $this->showFieldErrors = (bool) $enabled;
 
         return $this;
     }
@@ -724,7 +724,7 @@ class Form
     /**
      * Is client validation enabled?
      *
-     * @return boolean
+     * @return bool
      */
     public function clientValidationEnabled()
     {
@@ -734,12 +734,12 @@ class Form
     /**
      * Enable/disable client validation.
      *
-     * @param boolean $enable
+     * @param bool $enable
      * @return $this
      */
     public function setClientValidationEnabled($enable)
     {
-        $this->clientValidationEnabled = (boolean) $enable;
+        $this->clientValidationEnabled = (bool) $enable;
 
         return $this;
     }

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -1,4 +1,6 @@
-<?php  namespace Kris\LaravelFormBuilder;
+<?php
+
+namespace Kris\LaravelFormBuilder;
 
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
@@ -25,6 +27,7 @@ class FormBuilder
     /**
      * @param Container  $container
      * @param FormHelper $formHelper
+     * @param EventDispatcher $eventDispatcher
      */
     public function __construct(Container $container, FormHelper $formHelper, EventDispatcher $eventDispatcher)
     {
@@ -34,9 +37,11 @@ class FormBuilder
     }
 
     /**
-     * @param       $formClass
-     * @param       $options
-     * @param       $data
+     * Create a Form instance.
+     *
+     * @param string $formClass The name of the class that inherits \Kris\LaravelFormBuilder\Form.
+     * @param array $options|null
+     * @param array $data|null
      * @return Form
      */
     public function create($formClass, array $options = [], array $data = [])
@@ -67,7 +72,7 @@ class FormBuilder
     }
 
     /**
-     * Get the namespace from the config
+     * Get the namespace from the config.
      *
      * @return string
      */
@@ -83,11 +88,11 @@ class FormBuilder
     }
 
     /**
-     * Get instance of the empty form which can be modified
+     * Get instance of the empty form which can be modified.
      *
      * @param array $options
      * @param array $data
-     * @return Form
+     * @return \Kris\LaravelFormBuilder\Form
      */
     public function plain(array $options = [], array $data = [])
     {

--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -1,4 +1,6 @@
-<?php namespace Kris\LaravelFormBuilder;
+<?php
+
+namespace Kris\LaravelFormBuilder;
 
 use Illuminate\Foundation\AliasLoader;
 use Collective\Html\FormBuilder as LaravelForm;
@@ -36,6 +38,11 @@ class FormBuilderServiceProvider extends ServiceProvider
         $this->app->alias('laravel-form-builder', 'Kris\LaravelFormBuilder\FormBuilder');
     }
 
+    /**
+     * Register the form helper.
+     *
+     * @return void
+     */
     protected function registerFormHelper()
     {
         $this->app->singleton('laravel-form-helper', function ($app) {
@@ -48,6 +55,11 @@ class FormBuilderServiceProvider extends ServiceProvider
         $this->app->alias('laravel-form-helper', 'Kris\LaravelFormBuilder\FormHelper');
     }
 
+    /**
+     * Bootstrap the service.
+     *
+     * @return void
+     */
     public function boot()
     {
         $this->loadViewsFrom(__DIR__ . '/../../views', 'laravel-form-builder');
@@ -70,6 +82,8 @@ class FormBuilderServiceProvider extends ServiceProvider
     }
 
     /**
+     * Get the services provided by this provider.
+     *
      * @return string[]
      */
     public function provides()
@@ -78,7 +92,9 @@ class FormBuilderServiceProvider extends ServiceProvider
     }
 
     /**
-     * Add Laravel Form to container if not already set
+     * Add Laravel Form to container if not already set.
+     *
+     * @return void
      */
     private function registerFormIfHeeded()
     {
@@ -113,7 +129,7 @@ class FormBuilderServiceProvider extends ServiceProvider
     }
 
     /**
-     * Add Laravel Html to container if not already set
+     * Add Laravel Html to container if not already set.
      */
     private function registerHtmlIfNeeded()
     {
@@ -134,8 +150,9 @@ class FormBuilderServiceProvider extends ServiceProvider
     }
 
     /**
-     * Check if an alias already exists in the IOC
-     * @param $alias
+     * Check if an alias already exists in the IOC.
+     *
+     * @param string $alias
      * @return bool
      */
     private function aliasExists($alias)

--- a/src/Kris/LaravelFormBuilder/FormBuilderTrait.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderTrait.php
@@ -1,14 +1,16 @@
-<?php namespace Kris\LaravelFormBuilder;
+<?php
+
+namespace Kris\LaravelFormBuilder;
 
 trait FormBuilderTrait
 {
 
     /**
-     * Create a Form instance
+     * Create a Form instance.
      *
-     * @param string $name Full class name of the form class
-     * @param array  $options Options to pass to the form
-     * @param array  $data additional data to pass to the form
+     * @param string $name Full class name of the form class.
+     * @param array  $options Options to pass to the form.
+     * @param array  $data additional data to pass to the form.
      *
      * @return \Kris\LaravelFormBuilder\Form
      */
@@ -18,10 +20,10 @@ trait FormBuilderTrait
     }
 
     /**
-     * Create a plain Form instance
+     * Create a plain Form instance.
      *
-     * @param array $options Options to pass to the form
-     * @param array $data additional data to pass to the form
+     * @param array $options Options to pass to the form.
+     * @param array $data additional data to pass to the form.
      *
      * @return \Kris\LaravelFormBuilder\Form
      */

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -1,4 +1,6 @@
-<?php  namespace Kris\LaravelFormBuilder;
+<?php
+
+namespace Kris\LaravelFormBuilder;
 
 use Illuminate\Contracts\Support\MessageBag;
 use Illuminate\Contracts\View\Factory as View;
@@ -117,7 +119,7 @@ class FormHelper
     }
 
     /**
-     * Merge options array
+     * Merge options array.
      *
      * @param array $first
      * @param array $second
@@ -129,7 +131,7 @@ class FormHelper
     }
 
     /**
-     * Get proper class for field type
+     * Get proper class for field type.
      *
      * @param $type
      * @return string
@@ -162,7 +164,7 @@ class FormHelper
     }
 
     /**
-     * Convert array of attributes to html attributes
+     * Convert array of attributes to html attributes.
      *
      * @param $options
      * @return string
@@ -186,7 +188,7 @@ class FormHelper
     }
 
     /**
-     * Add custom field
+     * Add custom field.
      *
      * @param $name
      * @param $class
@@ -201,7 +203,7 @@ class FormHelper
     }
 
     /**
-     * Load custom field types from config file
+     * Load custom field types from config file.
      */
     private function loadCustomTypes()
     {
@@ -214,6 +216,10 @@ class FormHelper
         }
     }
 
+    /**
+     * @param object $model
+     * @return object|null
+     */
     public function convertModelToArray($model)
     {
         if (!$model) {
@@ -232,7 +238,7 @@ class FormHelper
     }
 
     /**
-     * Format the label to the proper format
+     * Format the label to the proper format.
      *
      * @param $name
      * @return string
@@ -280,6 +286,7 @@ class FormHelper
     }
 
     /**
+     * @param array $fields
      * @return array
      */
     public function mergeAttributes(array $fields)
@@ -293,8 +300,10 @@ class FormHelper
     }
 
     /**
-     * Alter a form's values recursively according to its fields
+     * Alter a form's values recursively according to its fields.
      *
+     * @param  Form  $form
+     * @param  array $values
      * @return void
      */
     public function alterFieldValues(Form $form, array &$values)
@@ -315,7 +324,7 @@ class FormHelper
     }
 
     /**
-     * Alter a form's validity recursively, and add messages with nested form prefix
+     * Alter a form's validity recursively, and add messages with nested form prefix.
      *
      * @return void
      */
@@ -339,7 +348,9 @@ class FormHelper
     }
 
     /**
-     * Add unprefixed messages with prefix to a MessageBag
+     * Add unprefixed messages with prefix to a MessageBag.
+     *
+     * @return void
      */
     public function appendMessagesWithPrefix(MessageBag $messageBag, $prefix, array $keyedMessages)
     {
@@ -387,7 +398,7 @@ class FormHelper
     }
 
     /**
-     * Check if field name is valid and not reserved
+     * Check if field name is valid and not reserved.
      *
      * @throws \InvalidArgumentException
      * @param string $name

--- a/src/Kris/LaravelFormBuilder/RulesParser.php
+++ b/src/Kris/LaravelFormBuilder/RulesParser.php
@@ -1,4 +1,6 @@
-<?php namespace Kris\LaravelFormBuilder;
+<?php
+
+namespace Kris\LaravelFormBuilder;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
@@ -329,13 +331,13 @@ class RulesParser
     }
 
     /**
-     * For numbers: Check an exact value
-     * For strings: Check the length of the string
+     * For numbers: Check an exact value.
+     * For strings: Check the length of the string.
      *
      *   size:5 --> min="5" max="5" (number)
      *   size:5 --> pattern=".{5}"  (text)
      *
-     * @param $param
+     * @param mixed $param
      * @return array
      *
      * @see http://laravel.com/docs/5.1/validation#rule-size
@@ -364,7 +366,7 @@ class RulesParser
      *
      *   in:foo,bar  --> pattern="foo|bar"
      *
-     * @param $params
+     * @param array $params
      * @return array
      *
      * @see http://laravel.com/docs/5.1/validation#rule-in
@@ -383,7 +385,7 @@ class RulesParser
      *
      *   not_in:foo,bar  --> pattern="(?:(?!^foo$|^bar$).)*"
      *
-     * @param $params
+     * @param array $params
      * @return array
      *
      * @see http://laravel.com/docs/5.1/validation#rule-not-in
@@ -391,7 +393,7 @@ class RulesParser
     protected function notIn($params)
     {
         return [
-            'pattern' => '(?:(?!^' . join('$|^', $params) . '$).)*',
+            'pattern' => '(?:(?!^' . implode('$|^', $params) . '$).)*',
             'title' => $this->getTitle('not_in'),
         ];
     }
@@ -454,21 +456,21 @@ class RulesParser
      *
      *  mimes:xls,xlsx  --> accept=".xls, .xlsx"
      *
-     * @param  array
+     * @param  array $params
      * @return array
      *
      * @see http://laravel.com/docs/5.1/validation#rule-mimes
      * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-accept
      */
-    protected function mimes($param)
+    protected function mimes($params)
     {
-        $mimes = '.' . implode(', .', $param);
+        $mimes = '.' . implode(', .', $params);
 
         return ['accept'  => $mimes];
     }
 
     /**
-     * Get the title, used for validating a rule
+     * Get the title, used for validating a rule.
      *
      * @param  string $rule
      * @param  array  $params
@@ -492,6 +494,11 @@ class RulesParser
         return in_array($this->field->getType(), (array) $types);
     }
 
+    /**
+     * Check if the field is numeric.
+     *
+     * @return boolean
+     */
     protected function isNumeric()
     {
         return $this->isType(['number', 'range']);

--- a/src/Kris/LaravelFormBuilder/RulesParser.php
+++ b/src/Kris/LaravelFormBuilder/RulesParser.php
@@ -183,7 +183,7 @@ class RulesParser
     /**
      * Check that a value is either 0 or 1, so it can be parsed as bool.
      *
-     *   boolean  --> pattern="0|1"
+     *   bool  --> pattern="0|1"
      *
      * @return array
      *
@@ -497,7 +497,7 @@ class RulesParser
     /**
      * Check if the field is numeric.
      *
-     * @return boolean
+     * @return bool
      */
     protected function isNumeric()
     {


### PR DESCRIPTION
Fixed some inconsistencies 
* Always using implode instead of 'join' once
* return types
* . on the end of a comment
* { class opening on new row. (same for functions)
* inheritdoc where possible
* properties don't require naming the $foo in the comment.
* Comments are no longer questions. 
* @params have types now.
* Naming boolean -> bool