### PR TITLE
throwResponse in Laravel 5.3+, old response otherwise

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -2,10 +2,10 @@
 
 namespace Kris\LaravelFormBuilder;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Contracts\Events\Dispatcher as EventDispatcher;
 use Illuminate\Contracts\Validation\Factory as ValidatorFactory;
 use Illuminate\Contracts\Validation\Validator;
-use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Arr;
 use Kris\LaravelFormBuilder\Events\AfterFieldCreation;
@@ -1137,7 +1137,7 @@ class Form
      * Redirects to a destination when form is invalid.
      *
      * @param  string|null $destination The target url.
-     * @return HttpResponseException
+     * @return \Illuminate\Http\Exception\HttpResponseException|\Illuminate\Http\Exceptions\HttpResponseException
      */
     public function redirectIfNotValid($destination = null)
     {
@@ -1150,7 +1150,12 @@ class Form
 
             $response = $response->withErrors($this->getErrors())->withInput();
 
-            throw new HttpResponseException($response);
+            $version = substr(Application::VERSION, 0, 3);
+            if (version_compare($version, '5.3', '<')) {
+                throw new \Illuminate\Http\Exception\HttpResponseException($response);
+            }
+
+            $response->throwResponse();
         }
     }
 


### PR DESCRIPTION
Test lowest versions of the required packages also. The Exception changed for 5.4 support (#310), but broke old support.

This check for pre-5.3 version and throws the old exception. New one uses the throwResponse trait added in 5.2.32; https://github.com/laravel/framework/blob/master/CHANGELOG-5.2.md#v5232-2016-05-17