### PR TITLE
Use primaryKey of model as default property_key

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/EntityType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/EntityType.php
@@ -17,7 +17,7 @@ class EntityType extends ChoiceType
             'class' => null,
             'query_builder' => null,
             'property' => 'name',
-            'property_key' => 'id',
+            'property_key' => null,
         ];
 
         return array_merge(parent::getDefaults(), $defaults);
@@ -47,6 +47,10 @@ class EntityType extends ChoiceType
 
         $entity = new $entity();
 
+        if ($key === null) {
+            $key = $entity->getKeyName();
+        }
+        
         if ($queryBuilder instanceof \Closure) {
             $data = $queryBuilder($entity);
         } else {

--- a/tests/Fields/EntityTypeTest.php
+++ b/tests/Fields/EntityTypeTest.php
@@ -102,6 +102,11 @@ class DummyModel {
         }
     }
 
+    public function getKeyName()
+    {
+        return 'id';
+    }
+    
     public function getData()
     {
         return $this->data;


### PR DESCRIPTION
Currently there is a fixed default value of 'id' for the property_key name. This is because the default primaryKey column in Laravel is also 'id'. But as we already instantiate the entity, this commit just requests from the entity what its key name is.