### PR TITLE
ChoiceType: Deal with child options

### DIFF
--- a/src/views/choice.php
+++ b/src/views/choice.php
@@ -10,7 +10,7 @@
 
 <?php if ($showField): ?>
     <?php foreach ((array)$options['children'] as $child): ?>
-        <?= $child->render(['selected' => $options['selected']], true, true, false) ?>
+        <?= $child->render(['attr' => $options['attr'], 'selected' => $options['selected']], true, true, false) ?>
     <?php endforeach; ?>
 
     <?php include 'help_block.php' ?>

--- a/src/views/choice.php
+++ b/src/views/choice.php
@@ -10,7 +10,7 @@
 
 <?php if ($showField): ?>
     <?php foreach ((array)$options['children'] as $child): ?>
-        <?= $child->render(['attr' => $options['attr'], 'selected' => $options['selected']], true, true, false) ?>
+        <?= $child->render($options['choice_options'], true, true, false) ?>
     <?php endforeach; ?>
 
     <?php include 'help_block.php' ?>


### PR DESCRIPTION
Now we can set up child options, for example **size** or **VueJS attributes**.

PHP:

```
$this->add('languages', 'choice', [
    'choices' => ['en' => 'English', 'fr' => 'French'],
    'multiple' => true
]);
```

Blade:

`{!! form_row($form->languages, ['attr' => ['size' => 10, '@input' => 'update']]) !!}`

Output before:

`<select class="form-control" multiple="1" id="languages[]" name="languages[]">`

Output after:

`<select class="form-control" multiple="1" size="10" @input="update" name="languages[]">`