### PR TITLE
+Extensible RulesParser

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -5,7 +5,6 @@ namespace Kris\LaravelFormBuilder\Fields;
 use Kris\LaravelFormBuilder\Form;
 use Illuminate\Database\Eloquent\Model;
 use Kris\LaravelFormBuilder\FormHelper;
-use Kris\LaravelFormBuilder\RulesParser;
 use Illuminate\Database\Eloquent\Collection;
 
 /**
@@ -234,7 +233,7 @@ abstract class FormField
     protected function prepareOptions(array $options = [])
     {
         $helper = $this->formHelper;
-        $rulesParser = new RulesParser($this);
+        $rulesParser = $helper->createRulesParser($this);
         $rules = $this->getOption('rules');
         $parsedRules = $rules ? $rulesParser->parse($rules) : [];
 

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -7,9 +7,10 @@ use Illuminate\Contracts\View\Factory as View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Translation\Translator;
 use Kris\LaravelFormBuilder\Fields\FormField;
 use Kris\LaravelFormBuilder\Form;
-use Illuminate\Translation\Translator;
+use Kris\LaravelFormBuilder\RulesParser;
 
 class FormHelper
 {
@@ -258,6 +259,15 @@ class FormHelper
         }
 
         return ucfirst(str_replace('_', ' ', $name));
+    }
+
+    /**
+     * @param FormField $field
+     * @return RulesParser
+     */
+    public function createRulesParser(FormField $field)
+    {
+        return new RulesParser($field);
     }
 
     /**

--- a/tests/RulesParserTest.php
+++ b/tests/RulesParserTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\InputType;
-use Kris\LaravelFormBuilder\RulesParser;
 
 class RulesParserTest extends FormBuilderTestCase
 {
@@ -14,7 +13,7 @@ class RulesParserTest extends FormBuilderTestCase
     {
         parent::setUp();
         $field = new InputType('address', 'text', $this->plainForm);
-        $this->parser = new RulesParser($field);
+        $this->parser = $this->formHelper->createRulesParser($field);
     }
 
     /** @test */


### PR DESCRIPTION
From #340 

This allows the developer to extend the RulesParser to add their own 'rule to attribute' logic.