### PR TITLE
Add ability to automatically validate Form classes

### DIFF
--- a/src/Kris/LaravelFormBuilder/Traits/ValidatesWhenResolved.php
+++ b/src/Kris/LaravelFormBuilder/Traits/ValidatesWhenResolved.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Kris\LaravelFormBuilder\Traits;
+
+trait ValidatesWhenResolved
+{
+    //
+}

--- a/tests/Fixtures/TestController.php
+++ b/tests/Fixtures/TestController.php
@@ -1,0 +1,11 @@
+<?php
+
+class TestController
+{
+
+    public function validate(TestForm $form)
+    {
+
+    }
+    
+}

--- a/tests/Fixtures/TestForm.php
+++ b/tests/Fixtures/TestForm.php
@@ -1,0 +1,16 @@
+<?php
+
+use Kris\LaravelFormBuilder\Form;
+use Kris\LaravelFormBuilder\Traits\ValidatesWhenResolved;
+
+class TestForm extends Form
+{
+    use ValidatesWhenResolved;
+
+    public function buildForm()
+    {
+        $this->add('name', 'text', ['rules' => ['required', 'min:3']]);
+        $this->add('email', 'text', ['rules' => ['required', 'email', 'min:3']]);
+    }
+
+}

--- a/tests/FormBuilderValidationTest.php
+++ b/tests/FormBuilderValidationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace {
+
+    use Kris\LaravelFormBuilder\Events\AfterFieldCreation;
+    use Kris\LaravelFormBuilder\Events\AfterFormCreation;
+    use Kris\LaravelFormBuilder\Form;
+    use Kris\LaravelFormBuilder\FormBuilder;
+    use Kris\LaravelFormBuilder\FormHelper;
+
+    class FormBuilderValidationTest extends FormBuilderTestCase
+    {
+        public function setUp()
+        {
+            parent::setUp();
+            $this->app->make('Illuminate\Contracts\Http\Kernel')->pushMiddleware('Illuminate\Session\Middleware\StartSession');
+        }
+
+        public function testItValidatesWhenResolved()
+        {
+            Route::post('/test', TestController::class.'@validate');
+
+            $this->post('/test', ['email' => 'foo@bar.com'])
+                ->assertRedirect('/')
+                ->assertSessionHasErrors(['name']);
+        }
+
+        public function testItDoesNotValidateGetRequests()
+        {
+            Route::get('/test', TestController::class.'@validate');
+
+            $this->get('/test', ['email' => 'foo@bar.com'])
+                ->assertStatus(200);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the ability to automatically validate form objects when they get resolved through Laravels IOC container.

The behavior is similar to the FormRequest validation, so you only need to typehint the form object in your controller. If the validation fails, the form will automatically trigger the `redirectIfNotValid` method.

Usage:

## Let your form class use the ValidatesWhenResolved trait
```php
<?php

use Kris\LaravelFormBuilder\Form;
use Kris\LaravelFormBuilder\Traits\ValidatesWhenResolved;

class TestForm extends Form
{
    use ValidatesWhenResolved;

    public function buildForm()
    {
        $this->add('name', 'text', ['rules' => ['required', 'min:3']]);
    }

}
```

## In your controllers POST method, typehint the TestForm

```php
<?php

class TestController
{

    public function validate(TestForm $form)
    {
        // Everything in here is automatically valid!
    }
    
}
```