### PR TITLE
Bug-fix: CollectionType.php

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -77,7 +77,7 @@ class CollectionType extends ParentType
         $this->children = [];
         $type = $this->getOption('type');
         $oldInput = $this->parent->getRequest()->old($this->getNameKey());
-        $currentInput = $this->parent->getRequest()->get($this->getNameKey());
+        $currentInput = $this->parent->getRequest()->input($this->getNameKey());
 
         try {
             $fieldType = $this->formHelper->getFieldType($type);


### PR DESCRIPTION
Use input() to correctly return the data from the current request so that, if it contains multiple rows, those rows can be read in as children of the Collection field.