### PR TITLE
Check if custom field already defined on rebuildForm

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -430,6 +430,17 @@ class Form
     {
         return array_key_exists($name, $this->fields);
     }
+    
+    /**
+     * Check if form has custom field
+     *
+     * @param $name
+     * @return bool
+     */
+    public function hasCustom($name)
+    {
+        return array_key_exists($name, $this->formHelper->customTypes);
+    }
 
     /**
      * Get all form options.
@@ -691,6 +702,10 @@ class Form
      */
     public function addCustomField($name, $class)
     {
+        if ($this->rebuilding && $this->hasCustom($name)) {
+            return $this;
+        }
+        
         $this->formHelper->addCustomField($name, $class);
     }
 

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -86,7 +86,7 @@ class FormHelper
      *
      * @var array
      */
-    private $customTypes = [];
+    public $customTypes = [];
 
     /**
      * @param View    $view


### PR DESCRIPTION
Prevent ```Custom field [name] already exists on this form object.``` error on addCustomField and rebuildForm.


