### PR TITLE
Adds form_fields helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -92,3 +92,12 @@ if (!function_exists('form_errors')) {
     }
 
 }
+
+if (!function_exists('form_fields')) {
+
+    function form_fields(Form $form, array $options = [])
+    {
+        return $form->renderForm($options, false, true, false);
+    }
+
+}


### PR DESCRIPTION
Adds a new `form_fields()` helper function which renders the contents of the form without the opening and closing `<form>` tags.