### PR TITLE
Ignore exception thrown in FormField when adding classes

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -76,8 +76,16 @@ class CollectionType extends ParentType
     {
         $this->children = [];
         $type = $this->getOption('type');
-        $oldInput = $this->parent->getRequest()->old($this->getNameKey());
-        $currentInput = $this->parent->getRequest()->get($this->getNameKey());
+
+        try {
+            $oldInput = $this->parent->getRequest()->old($this->getNameKey());
+            $currentInput = $this->parent->getRequest()->get($this->getNameKey());
+        } catch ( \Exception $e  ) {
+            // Ignore this
+            $oldInput = [];
+            $currentInput = [];
+        }
+
 
         try {
             $fieldType = $this->formHelper->getFieldType($type);

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -258,7 +258,11 @@ abstract class FormField
         }
 
         if ($this->parent->haveErrorsEnabled()) {
-            $this->addErrorClass();
+            try {
+                $this->addErrorClass();
+            } catch ( \Exception $e ) {
+                // Ignore this
+            }
         }
 
         if ($this->getOption('required') === true || isset($parsedRules['required'])) {


### PR DESCRIPTION
In my current project I made a Laravel Artisan Command that generates Migration files from a set of `Form` classes. This did not work as I was getting an `Exception` because no `Session` was available when the form builder gets to the point of assigning classnames to fields based on input from a `Request`.

This commit simply ignores this exception.

I don't know this is the correct way to do this however; so if you have any comments, please let me know and I'll figure out a better way (if this at all is accepted).