### PR TITLE
ParentType not pushing options to children

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -95,6 +95,30 @@ abstract class ParentType extends FormField
 
     /**
      * @inheritdoc
+         */
+    public function setOption($name, $value)
+    {
+        parent::setOption($name, $value);
+
+        foreach ((array) $this->children as $key => $child) {
+            $this->children[$key]->setOption($name, $value);
+        }
+    }
+
+    /**
+     * @inheritdoc
+         */
+    public function setOptions($options)
+    {
+        parent::setOptions($options);
+
+        foreach ((array) $this->children as $key => $child) {
+            $this->children[$key]->setOptions($options);
+        }
+    }
+
+    /**
+     * @inheritdoc
      */
     public function isRendered()
     {

--- a/tests/Fields/EntityTypeTest.php
+++ b/tests/Fields/EntityTypeTest.php
@@ -78,6 +78,36 @@ class EntityTypeTest extends FormBuilderTestCase
 
         $this->assertEquals($expected, $choice->getOption('choices'));
     }
+
+    /** @test */
+    public function options_are_passed_to_the_children()
+    {
+        $mdl = new DummyModel();
+        $options = [
+            'class' => 'DummyModel'
+        ];
+
+        $choice = new EntityType('entity_choice', 'entity', $this->plainForm, $options);
+        $choice->setOption('attr.data-key', 'value');
+
+        $field = $choice->render();
+
+        $expectedField = '<div class="form-group"  >
+    
+    <label for="entity_choice" class="control-label">Entity choice</label>
+            <select class="form-control" data-key="value" id="entity_choice" name="entity_choice"><option value="1">English</option><option value="2">French</option><option value="3">Serbian</option></select>    
+
+
+    
+    
+
+
+
+
+        </div>';
+
+        $this->assertEquals(trim($field), $expectedField);
+    }
 }
 
 class DummyModel {


### PR DESCRIPTION
The ParentType FormField's only copies the options supplied on FormField creation to their children. If you call 'setOption/setOptions' after creating e.g. an 'EntityField' the option is never passed to the child. This commit changes that behaviour by calling 'setOption/setOptions' on all children as well. See added test in EntityType for an use-case.