### PR TITLE
Include key in checkbox name when using multiple choice type.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
@@ -94,8 +94,6 @@ class ChoiceType extends ParentType
      */
     protected function buildCheckableChildren($fieldType)
     {
-        $multiple = $this->getOption('multiple') ? '[]' : '';
-
         foreach ((array)$this->options['choices'] as $key => $choice) {
             $id = str_replace('.', '_', $this->getNameKey()) . '_' . $key;
             $options = $this->formHelper->mergeOptions(
@@ -109,7 +107,7 @@ class ChoiceType extends ParentType
                 ]
             );
             $this->children[] = new $fieldType(
-                $this->name . $multiple,
+                $this->name . ($this->getOption('multiple') ? '[' . $key . ']' : ''),
                 $this->choiceType,
                 $this->parent,
                 $options


### PR DESCRIPTION
The following form:
```<?php

namespace App;

use Kris\LaravelFormBuilder\Form;

class TestForm extends Form
{
    public function buildForm()
    {
        $this
            ->add('choice', 'choice', [
                'multiple' => true,
                'expanded' => true,
                'choices' => [
                    'A',
                    'B',
                    'C',
                    'D',
                    'E',
                    'F'
                ]
            ])
            ->add('submit', 'submit');
    }
}
```
Results in:
![Form](https://user-images.githubusercontent.com/19206768/28163446-6fd857b2-67cb-11e7-8356-61bd1ce1eadb.png)

Selecting A & F results in the following array after submitting:
![Submitted form](https://user-images.githubusercontent.com/19206768/28163447-6fdbc10e-67cb-11e7-8f04-85224a629f61.png)
As you can see the indices being returned are 0 & 1, while 0 & 5 are selected.

I have changed the code so indices are included. I'm not sure if this is backwards compatible however, so please let me know.