### PR TITLE
If a form field is not required, it won't have any client validation enabled

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -295,11 +295,13 @@ abstract class FormField
 
             if ($this->parent->clientValidationEnabled()) {
                 $this->setOption('attr.required', 'required');
+            }
+        }
 
-                if ($parsedRules) {
-                    $attrs = $this->getOption('attr') + $parsedRules;
-                    $this->setOption('attr', $attrs);
-                }
+        if ($this->parent->clientValidationEnabled()) {
+            if ($parsedRules) {
+                $attrs = $this->getOption('attr') + $parsedRules;
+                $this->setOption('attr', $attrs);
             }
         }
 

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -298,11 +298,9 @@ abstract class FormField
             }
         }
 
-        if ($this->parent->clientValidationEnabled()) {
-            if ($parsedRules) {
-                $attrs = $this->getOption('attr') + $parsedRules;
-                $this->setOption('attr', $attrs);
-            }
+        if ($this->parent->clientValidationEnabled() && $parsedRules) {
+            $attrs = $this->getOption('attr') + $parsedRules;
+            $this->setOption('attr', $attrs);
         }
 
         $this->setOption('wrapperAttrs', $helper->prepareAttributes($this->getOption('wrapper')));

--- a/src/views/checkbox.php
+++ b/src/views/checkbox.php
@@ -5,6 +5,7 @@
 <?php endif; ?>
 
 <?php if ($showField): ?>
+    <?= Form::hidden($name, false) ?>
     <?= Form::checkbox($name, $options['value'], $options['checked'], $options['attr']) ?>
 
     <?php include 'help_block.php' ?>

--- a/src/views/checkbox.php
+++ b/src/views/checkbox.php
@@ -5,7 +5,6 @@
 <?php endif; ?>
 
 <?php if ($showField): ?>
-    <?= Form::hidden($name, false) ?>
     <?= Form::checkbox($name, $options['value'], $options['checked'], $options['attr']) ?>
 
     <?php include 'help_block.php' ?>


### PR DESCRIPTION
Just checked this with inputs and textareas.

This produces nothing:
```
'rules' => 'max:25',
```

This produces `required="required" maxlength="25"`
```
'rules' => 'required|max:25',
```
I very quickly created this PR, but I'm not sure it's actually a bug.

What do you think?