### PR TITLE
[NEW][Features] Added support override data of ChoiceType

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
@@ -69,9 +69,10 @@ class ChoiceType extends ParentType
      */
     protected function createChildren()
     {
-        if ($this->getOption('data_override') instanceof \Closure) {
-            $this->options['choices'] = $this->getOption('data_override')($this->options['choices'], $this);
+        if (($data_override = $this->getOption('data_override')) && $data_override instanceof \Closure) {
+            $this->options['choices'] = $data_override($this->options['choices'], $this);
         }
+        
         $this->children = [];
         $this->determineChoiceField();
 

--- a/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
@@ -69,6 +69,9 @@ class ChoiceType extends ParentType
      */
     protected function createChildren()
     {
+        if ($this->getOption('data_override') instanceof \Closure) {
+            $this->options['choices'] = $this->getOption('data_override')($this->options['choices'], $this);
+        }
         $this->children = [];
         $this->determineChoiceField();
 

--- a/tests/Fields/ChoiceTypeTest.php
+++ b/tests/Fields/ChoiceTypeTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\ChoiceType;
-use Kris\LaravelFormBuilder\Fields\SelectType;
-use Kris\LaravelFormBuilder\Form;
 
 class ChoiceTypeTest extends FormBuilderTestCase
 {
@@ -85,5 +83,27 @@ class ChoiceTypeTest extends FormBuilderTestCase
         $this->plainForm->renderForm();
 
         $this->assertEquals('users[]', $this->plainForm->users->getName());
+    }
+
+    /** @test */
+    public function it_can_override_choices()
+    {
+        $options = [
+            'choices' => ['yes' => 'Yes', 'no' => 'No'],
+            'selected' => 'test',
+            'data_override' => function ($choices, $field) {
+                $choices['test'] = 'test';
+
+                return $choices;
+            }
+        ];
+
+        $choice = new ChoiceType('some_choice', 'choice', $this->plainForm, $options);
+
+        $choice->render();
+
+        $this->assertEquals(3, count($choice->getOption('choices')));
+
+        $this->assertEquals('test', $choice->getOption('selected'));
     }
 }


### PR DESCRIPTION
sometimes maybe need to override choices the field with advanced logic, I know there is `query_builder` for `Entity` but its limit for a query & data from the database, but now can override data of all fields they base of `ChoiceType` field

Also, added simple test unit for this PR

example for using with `Entity` field

```php
        $this->add('languages', 'entity', [
            'class' => 'App\Language',
            'data_override' => function ($choices, $field) {
                $choices['testID’] = 'test';
                return $choices;
            }
        ]);
```