### PR TITLE
Fix: using properties that are populated via accessors

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/EntityType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/EntityType.php
@@ -85,10 +85,10 @@ class EntityType extends ChoiceType
 
         if (method_exists($data, 'pluck') || $data instanceof Model) {
             //laravel 5.3.*
-            return $data->pluck($value, $key);
+            return $data->get()->pluck($value, $key);
         } elseif (method_exists($data, 'lists')) {
             //laravel 5.2.*
-            return $data->lists($value, $key);
+            return $data->get()->lists($value, $key);
         }
     }
 }


### PR DESCRIPTION
Unable to use properties that are populated via accessor method in the 'property' option of Entity Type:

**In the Form class:**
`
->add('products', 'entity', [ ...
    'property' => 'name_translated',
... ])
`

**In the Product class:**
`public function getNameTranslatedAttribute()
{
    return ...;
}
`