### PR TITLE
Add translation template for labels

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChildFormType.php
@@ -116,7 +116,8 @@ class ChildFormType extends ParentType
             $options = [
                 'model' => $this->getOption($this->valueProperty) ?: $this->parent->getModel(),
                 'name' => $this->name,
-                'language_name' => $this->parent->getLanguageName()
+                'language_name' => $this->parent->getLanguageName(),
+                'translation_template' => $this->parent->getTranslationTemplate(),
             ];
 
             if (!$this->parent->clientValidationEnabled()) {
@@ -144,6 +145,10 @@ class ChildFormType extends ParentType
 
             if (!$class->getLanguageName()) {
                 $class->setLanguageName($this->parent->getLanguageName());
+            }
+
+            if (!$class->getTranslationTemplate()) {
+                $class->setTranslationTemplate($this->parent->getTranslationTemplate());
             }
 
             if (!$this->parent->clientValidationEnabled()) {

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -203,7 +203,8 @@ abstract class FormField
                 'options' => $this->options,
                 'showLabel' => $showLabel,
                 'showField' => $showField,
-                'showError' => $showError
+                'showError' => $showError,
+                'translationTemplate' => $this->parent->getTranslationTemplate(),
             ]
         )->render();
     }
@@ -593,7 +594,13 @@ abstract class FormField
             return;
         }
 
-        if ($langName = $this->parent->getLanguageName()) {
+        if ($template = $this->parent->getTranslationTemplate()) {
+            $label = str_replace(
+                ['{name}', '{type}'],
+                [$this->getRealName(), 'label'],
+                $template
+            );
+        } elseif ($langName = $this->parent->getLanguageName()) {
             $label = sprintf('%s.%s', $langName, $this->getRealName());
         } else {
             $label = $this->getRealName();

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -123,6 +123,11 @@ class Form
     protected $languageName;
 
     /**
+     * @var string
+     */
+    protected $translationTemplate;
+
+    /**
      * To filter and mutate request values or not.
      *
      * @var bool
@@ -491,6 +496,7 @@ class Form
         $this->pullFromOptions('client_validation', 'setClientValidationEnabled');
         $this->pullFromOptions('template_prefix', 'setTemplatePrefix');
         $this->pullFromOptions('language_name', 'setLanguageName');
+        $this->pullFromOptions('translation_template', 'setTranslationTemplate');
 
         return $this;
     }
@@ -866,6 +872,29 @@ class Form
     public function setLanguageName($prefix)
     {
         $this->languageName = (string) $prefix;
+
+        return $this;
+    }
+
+    /**
+     * Get the translation template.
+     *
+     * @return string
+     */
+    public function getTranslationTemplate()
+    {
+        return $this->translationTemplate;
+    }
+
+    /**
+     * Set a translation template, used to determine labels for fields.
+     *
+     * @param string $template
+     * @return $this
+     */
+    public function setTranslationTemplate($template)
+    {
+        $this->translationTemplate = (string) $template;
 
         return $this;
     }

--- a/tests/Fields/ChildFormTypeTest.php
+++ b/tests/Fields/ChildFormTypeTest.php
@@ -20,6 +20,18 @@ class ChildFormTypeTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_implicitly_inherits_translation_template()
+    {
+        $plainParent = $this->formBuilder->plain(['translation_template' => 'form.{name}.{type}']);
+        $plainChild = $this->formBuilder->plain();
+
+        $plainParent->add('a form', 'form', ['class' => $plainChild]);
+
+        $this->assertEquals($plainParent->getTranslationTemplate(), $plainChild->getTranslationTemplate());
+        $this->assertEquals('form.{name}.{type}', $plainChild->getTranslationTemplate());
+    }
+
+    /** @test */
     public function it_does_not_overwrite_language_name()
     {
         $plainParent = $this->formBuilder->plain(['language_name' => 'test_name']);
@@ -29,5 +41,17 @@ class ChildFormTypeTest extends FormBuilderTestCase
 
         $this->assertEquals('different_name', $plainChild->getLanguageName());
         $this->assertEquals('test_name', $plainParent->getLanguageName());
+    }
+
+    /** @test */
+    public function it_does_not_overwrite_translation_template()
+    {
+        $plainParent = $this->formBuilder->plain(['translation_template' => 'test.{name}']);
+        $plainChild = $this->formBuilder->plain(['translation_template' => 'different.{name}']);
+
+        $plainParent->add('a form', 'form', ['class' => $plainChild]);
+
+        $this->assertEquals('different.{name}', $plainChild->getTranslationTemplate());
+        $this->assertEquals('test.{name}', $plainParent->getTranslationTemplate());
     }
 }

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -172,6 +172,19 @@ class FormFieldTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_translates_the_label_using_translation_templates()
+    {
+        // We use build in validation translations prefix for easier testing
+        // just to make sure translation file is properly used
+        $this->plainForm->setTranslationTemplate('validation.{name}')->add('accepted', 'text');
+
+        $this->assertEquals(
+            'The :attribute must be accepted.',
+            $this->plainForm->accepted->getOption('label')
+        );
+    }
+
+    /** @test */
     public function provided_label_from_option_overrides_translated_one()
     {
         // We use build in validation translations prefix for easier testing


### PR DESCRIPTION
In some of our projects we use a language line system of:

```
'fields' => [
    'email' => [
        'label' => 'Email address',
        'placeholder' => '',
        'tooltip' => '',
        'help' => '',
    ],
    'password' => [
        'label' => 'Password',
        'placeholder' => '',
        'tooltip' => '',
        'help' => '',
    ],
    'submit' => [
        'label' => 'Log in',
    ],
],
```

This doesn't work with the current `language_name` functionality and would force us to manually write `trans('customer.login.fields.email.label')` for all fields.

This new functionality is fully backwards compatible with the old code, as long as you didn't use `translation_template` for custom functionality yet (highly unlikely).

Would love to hear what you think, and if you like it when you plan to release a new version.

Thanks in advance!