### PR TITLE
Escape static field value

### DIFF
--- a/src/views/static.php
+++ b/src/views/static.php
@@ -9,7 +9,7 @@
 <?php endif; ?>
 
 <?php if ($showField): ?>
-    <<?= $options['tag'] ?> <?= $options['elemAttrs'] ?>><?= $options['value'] ?></<?= $options['tag'] ?>>
+    <<?= $options['tag'] ?> <?= $options['elemAttrs'] ?>><?= htmlspecialchars($options['value']) ?></<?= $options['tag'] ?>>
 
     <?php include 'help_block.php' ?>
 


### PR DESCRIPTION
I didn't use Laravel's helper method e() to escape because I sense the templates were built avoiding any tight dependence with Laravel, so I tried to keep it that way.