### PR TITLE
fixed error with collection type

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -91,7 +91,7 @@ class CollectionType extends ParentType
         $data = $this->getOption($this->valueProperty, []);
 
         // If no value is provided, get values from current request.
-        if ($data && count($data) === 0) {
+        if (!is_null($data) && count($data) === 0) {
             $data = $currentInput;
         }
 


### PR DESCRIPTION
Checking trueness on empty array returns false, so while creating form, request data is ommited. Fixes #313 