### PR TITLE
Fix: lable and help_block position bug with radio and checkbox

### DIFF
--- a/src/views/checkbox.php
+++ b/src/views/checkbox.php
@@ -7,11 +7,11 @@
 <?php if ($showField): ?>
     <?= Form::checkbox($name, $options['value'], $options['checked'], $options['attr']) ?>
 
-    <?php include 'help_block.php' ?>
-<?php endif; ?>
+    <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
+        <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php include 'help_block.php' ?>
 <?php endif; ?>
 
 <?php include 'errors.php' ?>

--- a/src/views/radio.php
+++ b/src/views/radio.php
@@ -7,11 +7,11 @@
 <?php if ($showField): ?>
     <?= Form::radio($name, $options['value'], $options['checked'], $options['attr']) ?>
 
-    <?php include 'help_block.php' ?>
-<?php endif; ?>
+    <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
+        <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php include 'help_block.php' ?>
 <?php endif; ?>
 
 <?php include 'errors.php' ?>


### PR DESCRIPTION
#416 Move label position before help_block for checkbox and radio button.