### PR TITLE
add const to all types

### DIFF
--- a/src/Kris/LaravelFormBuilder/FieldTypesInterface.php
+++ b/src/Kris/LaravelFormBuilder/FieldTypesInterface.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: tresa
+ * Date: 9/19/2018
+ * Time: 10:04 AM
+ */
+
+namespace Kris\LaravelFormBuilder;
+
+
+interface FieldTypesInterface
+{
+    // FIELD fields
+    const FIELD_TEXT = 'text';
+    const FIELD_TEXTAREA = 'textarea';
+    const FIELD_SELECT = 'select';
+    const FIELD_CHOICE = 'choice';
+    const FIELD_CHECKBOX = 'checkbox';
+    const FIELD_RADIO = 'radio';
+    const FIELD_PASSWORD = 'password';
+    const FIELD_HIDDEN = 'hidden';
+    const FIELD_FILE = 'file';
+    const FIELD_STATIC = 'static';
+    //Date time fields
+    const FIELD_DATE = 'date';
+    const FIELD_DATETIME_LOCAL = 'datetime_local';
+    const FIELD_MONTH = 'month';
+    const FIELD_TIME = 'time';
+    const FIELD_WEEK = 'week';
+    //Special Purpose fields
+    const FIELD_COLOR = 'color';
+    const FIELD_SEARCH = 'search';
+    const FIELD_IMAGE = 'image';
+    const FIELD_EMAIL = 'email';
+    const FIELD_URL = 'url';
+    const FIELD_TEL = 'tel';
+    const FIELD_NUMBER = 'number';
+    const FIELD_RANGE = 'range';
+    //Buttons
+    const BUTTON_SUBMIT = 'submit';
+    const BUTTON_RESET = 'reset';
+    const BUTTON_BUTTON = 'button';
+}

--- a/src/Kris/LaravelFormBuilder/FieldTypesInterface.php
+++ b/src/Kris/LaravelFormBuilder/FieldTypesInterface.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: tresa
- * Date: 9/19/2018
- * Time: 10:04 AM
- */
 
 namespace Kris\LaravelFormBuilder;
 

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -14,7 +14,7 @@ use Kris\LaravelFormBuilder\Events\BeforeFormValidation;
 use Kris\LaravelFormBuilder\Fields\FormField;
 use Kris\LaravelFormBuilder\Filters\FilterResolver;
 
-class Form
+class Form implements FieldTypesInterface
 {
     /**
      * All fields that are added.


### PR DESCRIPTION
hello kirs
i create const in interface for from class to easy to use fields and faster to found.
when i use this package i had to any time check the uses field 
when we use const we don't need search any time for sepcial field


this form is readable than origin form 
`
class SongForm extends Form
{
    public function buildForm()
    {
        $this
            ->add('name', Form::FIELD_TEXT)
            ->add('lyrics', Form::FIELD_TEXTAREA)
            ->add('publish', Form::FIELD_CHECKBOX);
    }
}`
