### PR TITLE
add const to all types

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,19 +83,20 @@ Form is created in path `app/Forms/SongForm.php` with content:
 namespace App\Forms;
 
 use Kris\LaravelFormBuilder\Form;
+use Kris\LaravelFormBuilder\Field;
 
 class SongForm extends Form
 {
     public function buildForm()
     {
         $this
-            ->add('name', 'text', [
+            ->add('name', Field::TEXT, [
                 'rules' => 'required|min:5'
             ])
-            ->add('lyrics', 'textarea', [
+            ->add('lyrics', Field::TEXTAREA, [
                 'rules' => 'max:5000'
             ])
-            ->add('publish', 'checkbox');
+            ->add('publish', Field::CHECKBOX);
     }
 }
 ```
@@ -250,6 +251,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Routing\Controller as BaseController;
 use Kris\LaravelFormBuilder\FormBuilder;
+use Kris\LaravelFormBuilder\Field;
 use App\Forms\SongForm;
 
 class SongsController extends BaseController {
@@ -259,15 +261,15 @@ class SongsController extends BaseController {
         $form = $formBuilder->createByArray([
                         [
                             'name' => 'name',
-                            'type' => 'text',
+                            'type' => Field::TEXT,
                         ],
                         [
                             'name' => 'lyrics',
-                            'type' => 'textarea',
+                            'type' => Field::TEXTAREA,
                         ], 
                         [
                             'name' => 'publish',
-                            'type' => 'checkbox'
+                            'type' => Field::CHECKBOX
                         ],
                     ]
             ,[

--- a/src/Kris/LaravelFormBuilder/Field.php
+++ b/src/Kris/LaravelFormBuilder/Field.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Kris\LaravelFormBuilder;
+
+
+class Field
+{
+    // Simple fields
+    const TEXT = 'text';
+    const TEXTAREA = 'textarea';
+    const SELECT = 'select';
+    const CHOICE = 'choice';
+    const CHECKBOX = 'checkbox';
+    const RADIO = 'radio';
+    const PASSWORD = 'password';
+    const HIDDEN = 'hidden';
+    const FILE = 'file';
+    const STATIC = 'static';
+    //Date time fields
+    const DATE = 'date';
+    const DATETIME_LOCAL = 'datetime_local';
+    const MONTH = 'month';
+    const TIME = 'time';
+    const WEEK = 'week';
+    //Special Purpose fields
+    const COLOR = 'color';
+    const SEARCH = 'search';
+    const IMAGE = 'image';
+    const EMAIL = 'email';
+    const URL = 'url';
+    const TEL = 'tel';
+    const NUMBER = 'number';
+    const RANGE = 'range';
+    //Buttons
+    const BUTTON_SUBMIT = 'submit';
+    const BUTTON_RESET = 'reset';
+    const BUTTON_BUTTON = 'button';
+}


### PR DESCRIPTION
Hello Kris
I create const in interface for Form class to easy to use fields and faster to found.
When I use this package I should check the uses field every time.
when we use const we don't need search any time for special field

this form is readable than origin Form Class:

`class SongForm extends Form {
 public function buildForm() {
 $this ->add('name', Form::FIELD_TEXT) 
->add('lyrics', Form::FIELD_TEXTAREA) 
->add('publish', Form::FIELD_CHECKBOX); }
 }`
