### PR TITLE
 Fix custom options with default options merge

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -563,7 +563,7 @@ abstract class FormField
         $this->options = $this->prepareOptions($options);
 
         $defaults = $this->setDefaultClasses($options);
-        $this->options = $this->formHelper->mergeOptions($this->options, $defaults);
+        $this->options = $this->formHelper->mergeOptions($defaults, $this->options);
 
         $this->setupLabel();
     }


### PR DESCRIPTION
Otherwise the default options overwrite the custom ones

    $this->options = $this->formHelper->mergeOptions($defaults, $this->options);