### PR TITLE
Make sure subvalues is an array

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -343,7 +343,7 @@ class FormHelper
             if (method_exists($field, 'alterFieldValues')) {
                 $fullName = $this->transformToDotSyntax($name);
 
-                $subValues = Arr::get($values, $fullName);
+                $subValues = (array) Arr::get($values, $fullName);
                 $field->alterFieldValues($subValues);
                 Arr::set($values, $fullName, $subValues);
             }


### PR DESCRIPTION
A subform with checkboxes, with none checked, submits no values. If the complete form's values are retrieved with `getFieldValues(false)` (no nulls), the subform is empty (`null`), but `alterFieldValues` always expects an array.

I think I made this originally =) Sorry! Apparently I'm also the only one who uses it =)