### PR TITLE
Enable raw text inside labels

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -84,12 +84,13 @@ class FormBuilderServiceProvider extends ServiceProvider
         $form = $this->app['form'];
 
         $form->macro('customLabel', function($name, $value, $options = []) use ($form) {
+            $escape = !array_get($options, 'raw', true);
             if (isset($options['for']) && $for = $options['for']) {
                 unset($options['for']);
-                return $form->label($for, $value, $options);
+                return $form->label($for, $value, $options, $escape);
             }
 
-            return $form->label($name, $value, $options);
+            return $form->label($name, $value, $options, $escape);
         });
     }
 


### PR DESCRIPTION
Enable raw text inside label (disable escaping)

Example:

```
$this->add('title', 'text', [
    'label'      => '<small class="wow">test</small>',
    'label_attr' => [
        'raw' => true
    ]
]);
```
