### PR TITLE
Fixed: "datetime_local" to "datetime-local" as "_local" is not supported

### DIFF
--- a/src/Kris/LaravelFormBuilder/Field.php
+++ b/src/Kris/LaravelFormBuilder/Field.php
@@ -18,7 +18,7 @@ class Field
     const STATIC = 'static';
     //Date time fields
     const DATE = 'date';
-    const DATETIME_LOCAL = 'datetime_local';
+    const DATETIME_LOCAL = 'datetime-local';
     const MONTH = 'month';
     const TIME = 'time';
     const WEEK = 'week';


### PR DESCRIPTION
Hey

I was just using this as stumbled upon that error when importing via the `Field` constants.


Cheers