### PR TITLE
Better field rules collection, with AfterCollectingFieldRules event

### DIFF
--- a/src/Kris/LaravelFormBuilder/Events/AfterCollectingFieldRules.php
+++ b/src/Kris/LaravelFormBuilder/Events/AfterCollectingFieldRules.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Kris\LaravelFormBuilder\Events;
+
+use Kris\LaravelFormBuilder\Fields\FormField;
+use Kris\LaravelFormBuilder\Form;
+use Kris\LaravelFormBuilder\Rules;
+
+class AfterCollectingFieldRules
+{
+    /**
+     * The field instance.
+     *
+     * @var FormField
+     */
+    protected $field;
+
+    /**
+     * The field's rules.
+     *
+     * @var Rules
+     */
+    protected $rules;
+
+    /**
+     * Create a new after field creation instance.
+     *
+     * @param Form $form
+     * @param FormField $field
+     * @return void
+     */
+    public function __construct(FormField $field, Rules $rules) {
+        $this->field = $field;
+        $this->rules = $rules;
+    }
+
+    /**
+     * Return the event's field.
+     *
+     * @return FormField
+     */
+    public function getField() {
+        return $this->field;
+    }
+
+    /**
+     * Return the event's field's rules.
+     *
+     * @return Rules
+     */
+    public function getRules() {
+        return $this->rules;
+    }
+}

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -7,6 +7,7 @@ use Kris\LaravelFormBuilder\Filters\FilterInterface;
 use Kris\LaravelFormBuilder\Filters\FilterResolver;
 use Kris\LaravelFormBuilder\Form;
 use Kris\LaravelFormBuilder\FormHelper;
+use Kris\LaravelFormBuilder\Rules;
 
 /**
  * Class FormField
@@ -682,7 +683,7 @@ abstract class FormField
         }
 
         if (!$rules) {
-            return [];
+            return new Rules([]);
         }
 
         if (is_array($rules)) {
@@ -695,11 +696,11 @@ abstract class FormField
             }, $rules);
         }
 
-        return [
-            'rules' => [$name => $rules],
-            'attributes' => [$name => $this->getOption('label')],
-            'error_messages' => $messages
-        ];
+        return new Rules(
+            [$name => $rules],
+            [$name => $this->getOption('label')],
+            $messages
+        );
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -188,7 +188,7 @@ abstract class ParentType extends FormField
     {
         $rules = parent::getValidationRules();
         $childrenRules = $this->formHelper->mergeFieldsRules($this->children);
-        return array_replace_recursive($rules, $childrenRules);
 
+        return $rules->append($childrenRules);
     }
 }

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1179,11 +1179,11 @@ class Form
     public function validate($validationRules = [], $messages = [])
     {
         $fieldRules = $this->formHelper->mergeFieldsRules($this->fields);
-        $rules = array_merge($fieldRules['rules'], $validationRules);
-        $messages = array_merge($fieldRules['error_messages'], $messages);
+        $rules = array_merge($fieldRules->getRules(), $validationRules);
+        $messages = array_merge($fieldRules->getMessages(), $messages);
 
         $this->validator = $this->validatorFactory->make($this->getRequest()->all(), $rules, $messages);
-        $this->validator->setAttributeNames($fieldRules['attributes']);
+        $this->validator->setAttributeNames($fieldRules->getAttributes());
 
         $this->eventDispatcher->fire(new BeforeFormValidation($this, $this->validator));
 
@@ -1200,7 +1200,7 @@ class Form
     {
         $fieldRules = $this->formHelper->mergeFieldsRules($this->fields);
 
-        return array_merge($fieldRules['rules'], $overrideRules);
+        return array_merge($fieldRules->getRules(), $overrideRules);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/FormBuilder.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilder.php
@@ -43,6 +43,17 @@ class FormBuilder
     }
 
     /**
+     * Fire an event.
+     *
+     * @param object $event
+     * @return array|null
+     */
+    public function fireEvent($event)
+    {
+        return $this->eventDispatcher->fire($event);
+    }
+
+    /**
      * Create a Form instance.
      *
      * @param string $formClass The name of the class that inherits \Kris\LaravelFormBuilder\Form.

--- a/src/Kris/LaravelFormBuilder/Rules.php
+++ b/src/Kris/LaravelFormBuilder/Rules.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Kris\LaravelFormBuilder;
+
+class Rules
+{
+
+    /**
+     * @var array
+     */
+    protected $rules;
+
+    /**
+     * @var array
+     */
+    protected $attributes;
+
+    /**
+     * @var array
+     */
+    protected $messages;
+
+    /**
+     * @param array $rules
+     * @param array $attributes
+     * @param array $messages
+     */
+    public function __construct(array $rules, array $attributes = [], array $messages = []) {
+        $this->rules = $rules;
+        $this->attributes = $attributes;
+        $this->messages = $messages;
+    }
+
+    /**
+     * @param array $rules
+     * @param array $attributes
+     * @param array $messages
+     */
+    public function append($rules) {
+      if (is_array($rules)) {
+        $rules = static::fromArray($rules);
+      }
+
+      $this->rules = array_replace_recursive($this->rules, $rules->getRules());
+      $this->attributes = array_replace_recursive($this->attributes, $rules->getAttributes());
+      $this->messages = array_replace_recursive($this->messages, $rules->getMessages());
+
+      return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getRules() {
+      return $this->rules;
+    }
+
+    /**
+     * @return array
+     */
+    public function getAttributes() {
+      return $this->attributes;
+    }
+
+    /**
+     * @return array
+     */
+    public function getMessages() {
+      return $this->messages;
+    }
+
+    /**
+     * @param array[] $rules
+     * @return static
+     */
+    static public function fromArray($rules) {
+        if (!$rules) {
+            return new static([]);
+        }
+
+        $rules += [
+            'rules' => [],
+            'attributes' => [],
+            'error_messages' => [],
+        ];
+
+        return new static($rules['rules'], $rules['attributes'], $rules['error_messages']);
+    }
+
+}


### PR DESCRIPTION
My apps have custom fields and custom validators, but I want to use the form builder as pure as possible. An event for altering field rules would be perfect. Event `BeforeFormValidation` is too late, because it has prepared the entire validator already.

Patch is almost completely backward compatible, but not quite. The return type of `FormField::getValidationRules()` has changed from `array` to `Rules`. For new fields that's fine (because `Rules::fromArray`), but if a developer extends an existing field and expects an array from `parent::getValidationRules()`, that will crash.