### PR TITLE
don't always automatically copy parent setOption(s) to children

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -28,7 +28,7 @@ abstract class ParentType extends FormField
      */
     public function __construct($name, $type, Form $parent, array $options = [])
     {
-        parent::__construct($name, $type, $parent, $options);
+        parent::__construct($name, $type, $parent, $options + ['copy_options_to_children' => true]);
         // If there is default value provided and  setValue was not triggered
         // in the parent call, make sure we generate child elements.
         if ($this->hasDefault) {
@@ -95,25 +95,29 @@ abstract class ParentType extends FormField
 
     /**
      * @inheritdoc
-         */
+     */
     public function setOption($name, $value)
     {
         parent::setOption($name, $value);
 
-        foreach ((array) $this->children as $key => $child) {
-            $this->children[$key]->setOption($name, $value);
+        if ($this->options['copy_options_to_children']) {
+            foreach ((array) $this->children as $key => $child) {
+                $this->children[$key]->setOption($name, $value);
+            }
         }
     }
 
     /**
      * @inheritdoc
-         */
+     */
     public function setOptions($options)
     {
         parent::setOptions($options);
 
-        foreach ((array) $this->children as $key => $child) {
-            $this->children[$key]->setOptions($options);
+        if ($this->options['copy_options_to_children']) {
+            foreach ((array) $this->children as $key => $child) {
+                $this->children[$key]->setOptions($options);
+            }
         }
     }
 


### PR DESCRIPTION
I use `AfterFieldCreation` to set options and add classes to some fields automatically. But if I `setOption` a `ChildFormType`, the option is copied to all children. For some options that's good, but for some it's not (field type class).

With this new option, the developer can choose not to copy options:

    $events->listen(AfterFieldCreation::class, function(AfterFieldCreation $event) {
      $event->getField()->setOption('copy_options_to_children', FALSE);
      $event->getField()->setOption('wrapper.class', 'foo');
    });

The default is `true`, so it's fully bc.