### PR TITLE
+collection option prefer_input

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -38,7 +38,8 @@ class CollectionType extends ParentType
             'data' => null,
             'property' => 'id',
             'prototype_name' => '__NAME__',
-            'empty_row' => true
+            'empty_row' => true,
+            'prefer_input' => false,
         ];
     }
 
@@ -92,6 +93,10 @@ class CollectionType extends ParentType
 
         // If no value is provided, get values from current request.
         if (!is_null($data) && count($data) === 0) {
+            $data = $currentInput;
+        }
+        // Or if the current request input is preferred over original data.
+        elseif ($this->getOption('prefer_input') && count($currentInput)) {
             $data = $currentInput;
         }
 


### PR DESCRIPTION
If you always want POST data to be the guide of which collection items to validate & accept. If your model has a 2 item collection, and your POST submits 7 items, those 7 items will be validated, and returned by `getFieldValues`. 