### PR TITLE
501/refactor remove deprecated helpers laravel58

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ composer.lock
 .DS_Store
 .idea
 coverage
+*.taskpaper
+NOTES.md

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,10 @@
+# laravel-form-builder
+
+#501 Refactor to use Arr class for deprecated array helpers
+- array_get
+- array_pull
+- array_set
+- array_forget
+
+- str_is
+- str_contains

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,20 @@
 {
     "name": "kris/laravel-form-builder",
     "description": "Laravel form builder - symfony like",
-    "keywords": ["laravel", "form", "builder"],
+    "keywords": ["laravel", "form", "builder","symfony"],
     "license": "MIT",
     "authors": [
         {
             "name": "Kristijan Husak",
             "email": "husakkristijan@gmail.com"
+        },
+        {
+            "name": "Mike Erickson",
+            "email": "codedungeon@gmail.com"
+        },
+        {
+            "name": "Mike Erickson",
+            "email": "mike.erickson@codedungeon.io"
         }
     ],
     "require": {

--- a/phpunit-printer.yml
+++ b/phpunit-printer.yml
@@ -1,0 +1,14 @@
+options:
+  cd-printer-hide-class: false
+  cd-printer-simple-output: false
+  cd-printer-show-config: true
+  cd-printer-hide-namespace: true
+  cd-printer-anybar: false
+  cd-printer-anybar-port: 1738
+markers:
+  cd-pass: "✔︎ "
+  cd-fail: "✖ "
+  cd-error: "⚈ "
+  cd-skipped: "=> "
+  cd-incomplete: "∅ "
+  cd-risky: "⌽ "

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,14 +2,12 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
+         colors="true" convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
->
+         syntaxCheck="false">
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/Kris/LaravelFormBuilder/Console/FormMakeCommand.php
+++ b/src/Kris/LaravelFormBuilder/Console/FormMakeCommand.php
@@ -4,6 +4,7 @@ namespace Kris\LaravelFormBuilder\Console;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Arr;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -147,7 +148,7 @@ class FormMakeCommand extends GeneratorCommand
             $composerPath
         ), true);
 
-        return array_get($composer, 'autoload.psr-4', []);
+        return Arr::get($composer, 'autoload.psr-4', []);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -2,6 +2,8 @@
 
 namespace Kris\LaravelFormBuilder\Fields;
 
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use Kris\LaravelFormBuilder\Filters\Exception\FilterAlreadyBindedException;
 use Kris\LaravelFormBuilder\Filters\FilterInterface;
 use Kris\LaravelFormBuilder\Filters\FilterResolver;
@@ -235,7 +237,7 @@ abstract class FormField
         } elseif (is_object($model)) {
             return object_get($model, $transformedName);
         } elseif (is_array($model)) {
-            return array_get($model, $transformedName);
+            return Arr::get($model, $transformedName);
         }
     }
 
@@ -291,7 +293,7 @@ abstract class FormField
             $lblClass = $this->getOption('label_attr.class', '');
             $requiredClass = $this->getConfig('defaults.required_class', 'required');
 
-            if (! str_contains($lblClass, $requiredClass)) {
+            if (! Str::contains($lblClass, $requiredClass)) {
                 $lblClass .= ' '.$requiredClass;
                 $this->setOption('label_attr.class', $lblClass);
             }
@@ -371,7 +373,7 @@ abstract class FormField
      */
     public function getOption($option, $default = null)
     {
-        return array_get($this->options, $option, $default);
+        return Arr::get($this->options, $option, $default);
     }
 
     /**
@@ -396,7 +398,7 @@ abstract class FormField
      */
     public function setOption($name, $value)
     {
-        array_set($this->options, $name, $value);
+        Arr::set($this->options, $name, $value);
 
         return $this;
     }
@@ -582,13 +584,13 @@ abstract class FormField
         $field_class = $this->getConfig('defaults.' . $this->type . '.field_class', '');
 
         $defaults = [];
-        if ($wrapper_class && !array_get($options, 'wrapper.class')) {
+        if ($wrapper_class && !Arr::get($options, 'wrapper.class')) {
             $defaults['wrapper']['class'] = $wrapper_class;
         }
-        if ($label_class && !array_get($options, 'label_attr.class')) {
+        if ($label_class && !Arr::get($options, 'label_attr.class')) {
             $defaults['label_attr']['class'] = $label_class;
         }
-        if ($field_class && !array_get($options, 'attr.class')) {
+        if ($field_class && !Arr::get($options, 'attr.class')) {
             $defaults['attr']['class'] = $field_class;
         }
         return $defaults;
@@ -656,7 +658,7 @@ abstract class FormField
      */
     public function enable()
     {
-        array_forget($this->options, 'attr.disabled');
+        Arr::forget($this->options, 'attr.disabled');
 
         return $this;
     }

--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -2,6 +2,7 @@
 
 namespace Kris\LaravelFormBuilder\Fields;
 
+use Illuminate\Support\Arr;
 use Kris\LaravelFormBuilder\Form;
 
 abstract class ParentType extends FormField
@@ -76,7 +77,7 @@ abstract class ParentType extends FormField
      */
     public function getChild($key)
     {
-        return array_get($this->children, $key);
+        return Arr::get($this->children, $key);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -481,7 +481,7 @@ class Form
      */
     public function getFormOption($option, $default = null)
     {
-        return array_get($this->formOptions, $option, $default);
+        return Arr::get($this->formOptions, $option, $default);
     }
 
     /**
@@ -542,8 +542,8 @@ class Form
      */
     protected function pullFromOptions($name, $method)
     {
-        if (array_get($this->formOptions, $name) !== null) {
-            $this->{$method}(array_pull($this->formOptions, $name));
+        if (Arr::get($this->formOptions, $name) !== null) {
+            $this->{$method}(Arr::pull($this->formOptions, $name));
         }
     }
 
@@ -817,7 +817,7 @@ class Form
             return $this->data;
         }
 
-        return array_get($this->data, $name, $default);
+        return Arr::get($this->data, $name, $default);
     }
 
     /**
@@ -1024,7 +1024,7 @@ class Form
     protected function checkIfNamedForm()
     {
         if ($this->getFormOption('name')) {
-            $this->name = array_pull($this->formOptions, 'name', $this->name);
+            $this->name = Arr::pull($this->formOptions, 'name', $this->name);
         }
     }
 
@@ -1056,9 +1056,9 @@ class Form
         $isCollectionFormModel = preg_match('/^.*\.\d$/', $dotName);
         $isCollectionPrototype = strpos($dotName, '__NAME__') !== false;
 
-        if (!array_get($model, $dotName) && !$isCollectionFormModel && !$isCollectionPrototype) {
+        if (!Arr::get($model, $dotName) && !$isCollectionFormModel && !$isCollectionPrototype) {
             $newModel = [];
-            array_set($newModel, $dotName, $model);
+            Arr::set($newModel, $dotName, $model);
             $this->model = $newModel;
 
             return true;

--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -7,6 +7,7 @@ use Collective\Html\FormBuilder as LaravelForm;
 use Collective\Html\HtmlBuilder;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Application;
+use Illuminate\Support\Str;
 use Kris\LaravelFormBuilder\Traits\ValidatesWhenResolved;
 use Kris\LaravelFormBuilder\Form;
 
@@ -117,10 +118,10 @@ class FormBuilderServiceProvider extends ServiceProvider
                 // LaravelCollective\HtmlBuilder 5.2 is not backward compatible and will throw an exception
                 $version = substr(Application::VERSION, 0, 3);
 
-                if(str_is('5.4', $version)) {
+                if(Str::is('5.4', $version)) {
                     $form = new LaravelForm($app[ 'html' ], $app[ 'url' ], $app[ 'view' ], $app[ 'session.store' ]->token());
                 }
-                else if (str_is('5.0', $version) || str_is('5.1', $version)) {
+                else if (Str::is('5.0', $version) || Str::is('5.1', $version)) {
                     $form = new LaravelForm($app[ 'html' ], $app[ 'url' ], $app[ 'session.store' ]->token());
                 }
                 else {

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -113,7 +113,7 @@ class FormHelper
         $config = array_replace_recursive($this->config, $customConfig);
 
         if ($key) {
-            return array_get($config, $key, $default);
+            return Arr::get($config, $key, $default);
         }
 
         return $config;


### PR DESCRIPTION
Replaced the following helper methods, using the appropriate facade classes

- array_get
- array_pull
- array_set
- array_forget

- str_is
- str_contains