### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -186,8 +186,8 @@ namespace {
 
             $this->add('options', 'choice', [
                 'choices' => ['a' => 'Aaa', 'b' => 'Bbb'],
-                'expanded' => TRUE,
-                'multiple' => TRUE,
+                'expanded' => true,
+                'multiple' => true,
             ]);
 
             $this->add('subcustom', 'form', [


### PR DESCRIPTION
Hi, I've changed some PHP keywords to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!