### PR TITLE
Pass form instance to "entity" field queryBuilder

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/EntityType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/EntityType.php
@@ -52,7 +52,7 @@ class EntityType extends ChoiceType
         }
 
         if ($queryBuilder instanceof \Closure) {
-            $data = $queryBuilder($entity);
+            $data = $queryBuilder($entity, $this->parent);
         } else {
             $data = $entity;
         }


### PR DESCRIPTION
This makes it possible to react to the current model values in
the query builder.

Example:
A "category" dropdown of type "entity".
Its queryBuilder adjusts the query to only show public categories.
When editing a model that already has a non-public category selected,
the query builder is now able to take this into account and
show public categories plus the currently selected non-public/internal
category.