### PR TITLE
add explicit collection empty row data

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -117,8 +117,9 @@ class CollectionType extends ParentType
         }
 
         if (!$data || empty($data)) {
-            if ($this->getOption('empty_row')) {
-                return $this->children[] = $this->setupChild(clone $field, '[0]');
+            if ($empty = $this->getOption('empty_row')) {
+                $val = $empty === true ? null : $empty;
+                return $this->children[] = $this->setupChild(clone $field, '[0]', $val);
             }
 
             return $this->children = [];


### PR DESCRIPTION
Without this patch a `ChildFormType` without data (e.g. a collection's `empty_row` item) will set the parent model as its model.

In `ChildFormType::getClassFromOptions()`:

```
$options = [
    'model' => $this->getOption($this->valueProperty) ?: $this->parent->getModel(),
    // ...
];
```

I don't know why, it's weird, but it might have a reason, so I won't break that.

This patch allows the parent form to define the `empty_row`'s data, so not `null` is passed through, so not the parent model is used:

```
// In the parent form: e.g. InvoiceForm
// $this->model instanceof Invoice

$this->add('items', 'collection', [
	'label' => 'Items',
	'type' => 'form',
	// 'data' => [], // Or empty because $this->model->items is empty
	'empty_row' => new InvoiceItem(), // truthy, but not `true`
	'options' => [
		'class' => InvoiceItemForm::class,
	],
]);
```

The `empty_row` subform will now have the `new InvoiceItem()` as model instead of the parent's `Invoice`.

If the subform should have access to the parent model, the developer can choose to include it via the child model, e.g.:

```
'empty_row' => new InvoiceItem(['invoice' => $this->model]),
```

because subforms don't have access to their parent form.