### PR TITLE
Try to avoid converting model to array.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -231,14 +231,7 @@ abstract class FormField
      */
     protected function getModelValueAttribute($model, $name)
     {
-        $transformedName = $this->transformKey($name);
-        if (is_string($model)) {
-            return $model;
-        } elseif (is_object($model)) {
-            return object_get($model, $transformedName);
-        } elseif (is_array($model)) {
-            return Arr::get($model, $transformedName);
-        }
+        return $this->formHelper->getModelValue($model, $name);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1052,14 +1052,18 @@ class Form
         }
 
         $dotName = $this->formHelper->transformToDotSyntax($this->getName());
-        $model = $this->formHelper->convertModelToArray($this->getModel());
+        $model = $this->getModel();
         $isCollectionFormModel = (bool) preg_match('/^.*\.\d+$/', $dotName);
         $isCollectionPrototype = strpos($dotName, '__NAME__') !== false;
 
-        if (!Arr::get($model, $dotName) && !$isCollectionFormModel && !$isCollectionPrototype) {
+        if (!$this->formHelper->getModelValue($model, $dotName) && !$isCollectionFormModel && !$isCollectionPrototype) {
             $newModel = [];
             Arr::set($newModel, $dotName, $model);
             $this->model = $newModel;
+
+            if (is_object($model)) {
+                $this->model = (object) $newModel;
+            }
 
             return true;
         }

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -457,4 +457,15 @@ class FormHelper
 
         return true;
     }
+
+    public function getModelValue($model, $name) {
+        $transformedName = $this->transformToDotSyntax($name);
+        if (is_string($model)) {
+            return $model;
+        } elseif (is_object($model)) {
+            return object_get($model, $transformedName);
+        } elseif (is_array($model)) {
+            return Arr::get($model, $transformedName);
+        }
+    }
 }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -830,9 +830,9 @@ class FormTest extends FormBuilderTestCase
             'gender' => 'f'
         ]);
 
-        $expectModel = [
-            'test_name' => $model->all()
-        ];
+        $expectModel = new StdClass;
+        $expectModel->test_name = $model;
+
         $this->plainForm
             ->add('name', 'text')
             ->add('address', 'static');


### PR DESCRIPTION
This could potentially fix issue that is trying to be fixed with https://github.com/kristijanhusak/laravel-form-builder/pull/519. I know we previously had bug reports where people didn't expect something to be an array  when they pass down a Model instance, or an object.

I barely tested this, so i need some testers to see if this could work out. If you know a better way to add a namespace to a model without breaking any structure, let me know.

This could maybe cause issues with lots of nested data. Converting array to object does it only on top level.

@rudiedirkx it would be great if you could test this and see if it works.