### PR TITLE
alterFieldValues() order+

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -344,9 +344,6 @@ class FormHelper
      */
     public function alterFieldValues(Form $form, array &$values)
     {
-        // Alter the form itself
-        $form->alterFieldValues($values);
-
         // Alter the form's child forms recursively
         foreach ($form->getFields() as $name => $field) {
             if (method_exists($field, 'alterFieldValues')) {
@@ -357,6 +354,9 @@ class FormHelper
                 Arr::set($values, $fullName, $subValues);
             }
         }
+
+        // Alter the form itself
+        $form->alterFieldValues($values);
     }
 
     /**


### PR DESCRIPTION
If the parent form's `alterFieldValues()` comes last, it has ultimate control, over its child forms too. Otherwise it can't change/unset/move child form values.