### PR TITLE
Add support Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "laravelcollective/html": "5.*",
-        "illuminate/database": "5.*@dev",
-        "illuminate/validation": "5.*@dev"
+        "laravelcollective/html": "5.*|^6.0",
+        "illuminate/database": "5.*@dev|^6.0",
+        "illuminate/validation": "5.*@dev|^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.0",


### PR DESCRIPTION
All deprecated helpers are removed in PR #504 so I think it would work fine on Laravel 6.0.