### PR TITLE
Added Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: ['7.1', '7.2', '7.3', '7.4', '8.0']
         package-release: [source, dist]
     steps:
       - name: Checkout repository
@@ -40,6 +40,10 @@ jobs:
             composer-${{ runner.os }}-${{ matrix.php }}-${{ matrix.package-release }}-
             composer-${{ runner.os }}-${{ matrix.php }}-
             composer-${{ runner.os }}-
+
+      - name: Pretend to be PHP 7.4
+        if: matrix.php == '8.0'
+        run: composer config platform.php 7.4.2
 
       - name: Install composer dependencies
         run: composer install --no-suggest --no-progress --no-interaction --prefer-${{ matrix.package-release }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,53 @@
+name: "Run unit tests"
+
+on:
+  - push
+
+env:
+  COMPOSER_MEMORY_LIMIT: -1
+
+jobs:
+  test:
+    name: "Build"
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 12
+      matrix:
+        php: ['7.1', '7.2', '7.3', '7.4']
+        package-release: [source, dist]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: exif,json,mbstring,dom
+
+      - name: Get user-level Composer cache
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Setup Composer cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: composer-${{ runner.os }}-${{ matrix.php }}-${{ matrix.package-release }}-${{ hashFiles('**/composer.json') }}
+          restore-keys: |
+            composer-${{ runner.os }}-${{ matrix.php }}-${{ matrix.package-release }}-${{ env.cache-name }}-
+            composer-${{ runner.os }}-${{ matrix.php }}-${{ matrix.package-release }}-
+            composer-${{ runner.os }}-${{ matrix.php }}-
+            composer-${{ runner.os }}-
+
+      - name: Install composer dependencies
+        run: composer install --no-suggest --no-progress --no-interaction --prefer-${{ matrix.package-release }}
+
+      - name: Run unit tests
+        run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+
+      - name: Upload to Scrutinizer
+        continue-on-error: true
+        run: |
+          wget https://scrutinizer-ci.com/ocular.phar
+          php ocular.phar code-coverage:upload --format=php-clover coverage.clover

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: "Run unit tests"
 
 on:
   - push
+  - pull_request
 
 env:
   COMPOSER_MEMORY_LIMIT: -1


### PR DESCRIPTION
Although Travis CI works fine too, since this is hosted on GitHub and since you're going to start on a V2, I made the guess to add GitHub Actions support to the repo.

Currently test PHP 5.6 - 7.4, with releases from source (`--prefer-source`) and from releases (`--prefer-dist`), since users are more likely to get assets from the latter.

There's an option to add Windows and Mac OS to the matrix, but it'd result in 18 jobs, which seems  a bit too enthusiastic.