### PR TITLE
Change ParentType so it merges arrays to prevent overwriting default options of children.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -103,7 +103,7 @@ abstract class ParentType extends FormField
 
         if ($this->options['copy_options_to_children']) {
             foreach ((array) $this->children as $key => $child) {
-                $this->children[$key]->setOption($name, $value);
+                $this->children[$key]->setOption($name, is_array($value) ? array_merge($value, $this->children[$key]->getOption($name)) : $value);
             }
         }
     }

--- a/tests/Fields/ChoiceTypeTest.php
+++ b/tests/Fields/ChoiceTypeTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Kris\LaravelFormBuilder\Fields\CheckableType;
 use Kris\LaravelFormBuilder\Fields\ChoiceType;
 
 class ChoiceTypeTest extends FormBuilderTestCase
@@ -105,5 +106,30 @@ class ChoiceTypeTest extends FormBuilderTestCase
         $this->assertEquals(3, count($choice->getOption('choices')));
 
         $this->assertEquals('test', $choice->getOption('selected'));
+    }
+
+    /** @test */
+    public function it_keeps_default_options_from_children()
+    {
+        $options = [
+            'rules' => 'required',
+            'choices' => ['yes' => 'Yes', 'no' => 'No'],
+            'expanded' => true,
+            'multiple' => true,
+        ];
+
+        $choice = new ChoiceType('some_choice', 'choice', $this->plainForm, $options);
+
+        $choice->render();
+
+        $this->assertEquals(2, count($choice->getChildren()));
+
+        $this->assertContainsOnlyInstancesOf(CheckableType::class, $choice->getChildren());
+
+        /** @var CheckableType $firstChoice */
+        $firstChoice = $choice->getChildren()[0];
+
+        $this->assertEquals('some_choice_yes', $firstChoice->getOption('attr.id'));
+        $this->assertEquals($firstChoice->getOption('label_attr.for'), $firstChoice->getOption('attr.id'));
     }
 }


### PR DESCRIPTION
This PR is meant to fix #445.

The application I'm working on does not display the checkboxes, but rather it displays a label. Clicking on the label changes the checkbox.
For this to work the label has the `for` attribute, which matches the checkbox `id` attribute.

Without this fix the id is not passed to the checkbox causing the checkbox to not work properly.