### PR TITLE
Merge pull request #574 from yaquawa/remove_fields

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -340,13 +340,15 @@ class Form
     /**
      * Remove field with specified name from the form.
      *
-     * @param $name
+     * @param string|string[] $names
      * @return $this
      */
-    public function remove($name)
+    public function remove($names)
     {
-        if ($this->has($name)) {
-            unset($this->fields[$name]);
+        foreach (is_array($names) ? $names : func_get_args() as $name) {
+            if ($this->has($name)) {
+                unset($this->fields[$name]);
+            }
         }
 
         return $this;

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -448,11 +448,12 @@ class FormTest extends FormBuilderTestCase
 
         $this->assertTrue($this->plainForm->has('name'));
 
-        $this->plainForm->remove('name');
+        $this->plainForm->remove('name', 'description');
 
-        $this->assertEquals(2, count($this->plainForm->getFields()));
+        $this->assertEquals(1, count($this->plainForm->getFields()));
 
         $this->assertFalse($this->plainForm->has('name'));
+        $this->assertFalse($this->plainForm->has('description'));
     }
 
     /** @test */


### PR DESCRIPTION
Just make the `remove` method more easier to use.

### Before
```php
$form->remove('filed_1')->remove('field_2');
```

### After
```php
$form->remove('filed_1', 'field_2');

// or $form->remove(['filed_1', 'field_2'])

```