### PR TITLE
Added `getNameKey` method to Form class

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -677,7 +677,7 @@ abstract class FormField
         $rules = $this->getOption('rules', []);
         $name = $this->getNameKey();
         $messages = $this->getOption('error_messages', []);
-        $formName = $this->formHelper->transformToDotSyntax($this->parent->getName());
+        $formName = $this->parent->getNameKey();
 
         if ($messages && $formName) {
             $newMessages = [];

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1082,7 +1082,7 @@ class Form
             return false;
         }
 
-        $dotName = $this->formHelper->transformToDotSyntax($this->getName());
+        $dotName = $this->getNameKey();
         $model = $this->formHelper->convertModelToArray($this->getModel());
         $isCollectionFormModel = (bool) preg_match('/^.*\.\d+$/', $dotName);
         $isCollectionPrototype = strpos($dotName, '__NAME__') !== false;
@@ -1335,8 +1335,8 @@ class Form
         }
 
         // If this form is a child form, cherry pick a part
-        if ($prefix = $this->getName()) {
-            $prefix = $this->formHelper->transformToDotSyntax($prefix);
+        if ($this->getName()) {
+            $prefix = $this->getNameKey();
             $values = Arr::get($values, $prefix);
         }
 
@@ -1381,7 +1381,7 @@ class Form
             $filters = array_filter($this->getFilters());
 
             if (count($filters)) {
-                $dotForm = $this->formHelper->transformToDotSyntax($this->getName());
+                $dotForm = $this->getNameKey();
 
                 $request = $this->getRequest();
                 $requestData = $request->all();

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -355,6 +355,25 @@ class Form
     }
 
     /**
+     * Take only the given fields from the form.
+     *
+     * @param string|string[] $fieldNames
+     * @return $this
+     */
+    public function only($fieldNames)
+    {
+        $newFields = [];
+
+        foreach (is_array($fieldNames) ? $fieldNames : func_get_args() as $fieldName) {
+            $newFields[$fieldName] = $this->getField($fieldName);
+        }
+
+        $this->fields = $newFields;
+
+        return $this;
+    }
+
+    /**
      * Modify existing field. If it doesn't exist, it is added to form.
      *
      * @param string $name

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -625,6 +625,16 @@ class Form
     }
 
     /**
+     * Get dot notation key for the form.
+     *
+     * @return string
+     **/
+    public function getNameKey()
+    {
+        return $this->formHelper->transformToDotSyntax($this->name);
+    }
+
+    /**
      * Set the name of the form.
      *
      * @param string $name

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -340,13 +340,15 @@ class Form
     /**
      * Remove field with specified name from the form.
      *
-     * @param $name
+     * @param string|string[] $names
      * @return $this
      */
-    public function remove($name)
+    public function remove($names)
     {
-        if ($this->has($name)) {
-            unset($this->fields[$name]);
+        foreach (is_array($names) ? $names : func_get_args() as $name) {
+            if ($this->has($name)) {
+                unset($this->fields[$name]);
+            }
         }
 
         return $this;

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -448,11 +448,12 @@ class FormTest extends FormBuilderTestCase
 
         $this->assertTrue($this->plainForm->has('name'));
 
-        $this->plainForm->remove('name');
+        $this->plainForm->remove('name', 'description');
 
-        $this->assertEquals(2, count($this->plainForm->getFields()));
+        $this->assertEquals(1, count($this->plainForm->getFields()));
 
         $this->assertFalse($this->plainForm->has('name'));
+        $this->assertFalse($this->plainForm->has('description'));
     }
 
     /** @test */

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -457,6 +457,24 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_can_take_and_replace_existing_fields()
+    {
+        $this->plainForm
+            ->add('name', 'text')
+            ->add('description', 'textarea')
+            ->add('remember', 'checkbox');
+
+        $this->plainForm->only('remember', 'name');
+
+        $this->assertEquals(2, count($this->plainForm->getFields()));
+        
+        $this->assertTrue($this->plainForm->has('remember'));
+        $this->assertTrue($this->plainForm->has('name'));
+        $this->assertFalse($this->plainForm->has('description'));
+    }
+
+
+    /** @test */
     public function it_can_modify_existing_fields()
     {
         $this->plainForm


### PR DESCRIPTION
Added a new method `getNameKey` to Form class to align to the method `\Kris\LaravelFormBuilder\Fields\FormField::getNameKey`.

This is useful when creating nested validation rules.