### PR TITLE
Fix `mergeOptions` behavior

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=5.6.0",
         "laravelcollective/html": "5.*|^6.0",
         "illuminate/database": "5.*@dev|^6.0",
         "illuminate/validation": "5.*@dev|^6.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.0",
         "laravelcollective/html": "5.*|^6.0",
         "illuminate/database": "5.*@dev|^6.0",
         "illuminate/validation": "5.*@dev|^6.0"

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,13 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
-        "laravelcollective/html": "5.*|^6.0",
-        "illuminate/database": "5.*@dev|^6.0",
-        "illuminate/validation": "5.*@dev|^6.0"
+        "php": ">=7.1",
+        "laravelcollective/html": "5.6.*|^6.0",
+        "illuminate/database": "5.6.*@dev|^6.0",
+        "illuminate/validation": "5.6.*@dev|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
-        "orchestra/testbench": "~3.4"
+        "orchestra/testbench": "~3.6"
     },
     "extra": {
         "branch-alias": {

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -130,13 +130,23 @@ class FormHelper
     /**
      * Merge options array.
      *
-     * @param array $first
-     * @param array $second
+     * @param array $targetOptions
+     * @param array $sourceOptions
      * @return array
      */
-    public function mergeOptions(array $first, array $second)
+    public function mergeOptions(array $targetOptions, array $sourceOptions)
     {
-        return array_replace_recursive($first, $second);
+        if (array_key_exists('+rules', $sourceOptions)) {
+            $mergedRules = array_values(array_unique(array_merge($targetOptions['rules'] ?? [], $sourceOptions['+rules'])));
+            $targetOptions['rules'] = $mergedRules;
+            unset($sourceOptions['+rules']);
+        }
+
+        if (array_key_exists('rules', $targetOptions) && array_key_exists('rules', $sourceOptions)) {
+            unset($targetOptions['rules']);
+        }
+
+        return array_replace_recursive($targetOptions, $sourceOptions);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -136,55 +136,9 @@ class FormHelper
      */
     public function mergeOptions(array $targetOptions, array $sourceOptions)
     {
-        // Normalize rules
-        if (array_key_exists('rules_append', $sourceOptions)) {
-            $sourceOptions['rules_append'] = $this->normalizeRules($sourceOptions['rules_append']);
-        }
-
-        if (array_key_exists('rules', $sourceOptions)) {
-            $sourceOptions['rules'] = $this->normalizeRules($sourceOptions['rules']);
-        }
-
-        if (array_key_exists('rules', $targetOptions)) {
-            $targetOptions['rules'] = $this->normalizeRules($targetOptions['rules']);
-        }
-
-
-        // Append rules
-        if ($rulesToBeAppended = Arr::pull($sourceOptions, 'rules_append')) {
-            $mergedRules = array_values(array_unique(array_merge($targetOptions['rules'], $rulesToBeAppended)));
-            $targetOptions['rules'] = $mergedRules;
-        }
-
         return array_replace_recursive($targetOptions, $sourceOptions);
     }
 
-    /**
-     * Normalize the the given rule expression to an array.
-     * @param mixed $rules
-     * @return array
-     */
-    public function normalizeRules($rules)
-    {
-        if (empty($rules)) {
-            return [];
-        }
-
-        if (is_string($rules)) {
-            return explode('|', $rules);
-        }
-
-        if (is_array($rules)) {
-            $normalizedRules = [];
-            foreach ($rules as $rule) {
-                $normalizedRules[] = $this->normalizeRules($rule);
-            }
-
-            return array_values(array_unique(Arr::flatten($normalizedRules)));
-        }
-
-        return $rules;
-    }
 
     /**
      * Get proper class for field type.

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -137,8 +137,8 @@ class FormHelper
     public function mergeOptions(array $targetOptions, array $sourceOptions)
     {
         // Normalize rules
-        if (array_key_exists('+rules', $sourceOptions)) {
-            $sourceOptions['+rules'] = $this->normalizeRules($sourceOptions['+rules']);
+        if (array_key_exists('rules_append', $sourceOptions)) {
+            $sourceOptions['rules_append'] = $this->normalizeRules($sourceOptions['rules_append']);
         }
 
         if (array_key_exists('rules', $sourceOptions)) {
@@ -151,15 +151,9 @@ class FormHelper
 
 
         // Append rules
-        if ($rulesToBeAppended = Arr::pull($sourceOptions, '+rules')) {
+        if ($rulesToBeAppended = Arr::pull($sourceOptions, 'rules_append')) {
             $mergedRules = array_values(array_unique(array_merge($targetOptions['rules'], $rulesToBeAppended)));
             $targetOptions['rules'] = $mergedRules;
-        }
-
-
-        // Replace rules
-        if (array_key_exists('rules', $targetOptions) && array_key_exists('rules', $sourceOptions)) {
-            unset($targetOptions['rules']);
         }
 
         return array_replace_recursive($targetOptions, $sourceOptions);

--- a/src/Kris/LaravelFormBuilder/RulesParser.php
+++ b/src/Kris/LaravelFormBuilder/RulesParser.php
@@ -595,14 +595,6 @@ class RulesParser
      */
     protected function getRulesAsArray($rules)
     {
-        $rulesArray = (is_string($rules)) ? explode('|', $rules) : $rules;
-
-        return array_map(function ($rule) {
-            if ($rule instanceof \Closure) {
-                return $rule($this->field->getNameKey());
-            }
-
-            return $rule;
-        }, $rulesArray);
+        return is_string($rules) ? explode('|', $rules) : (array)$rules;
     }
 }

--- a/tests/Console/FormGeneratorTest.php
+++ b/tests/Console/FormGeneratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Kris\LaravelFormBuilder\Console\FormGenerator;
+use PHPUnit\Framework\TestCase;
 
-class FormGeneratorTest extends PHPUnit_Framework_TestCase
+class FormGeneratorTest extends TestCase
 {
 
     /**
@@ -10,7 +11,7 @@ class FormGeneratorTest extends PHPUnit_Framework_TestCase
      */
     protected $formGenerator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->formGenerator = new FormGenerator();
     }

--- a/tests/Fields/ButtonTypeTest.php
+++ b/tests/Fields/ButtonTypeTest.php
@@ -87,6 +87,6 @@ class ButtonTypeTest extends FormBuilderTestCase
         $renderedView = $button->render();
 
         $this->assertEquals($expectedOptions, $button->getOptions());
-        $this->assertContains('<input', $renderedView);
+        $this->assertStringContainsString('<input', $renderedView);
     }
 }

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -141,10 +141,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \Exception
          */
         public function it_throws_exception_when_requesting_prototype_while_it_is_disabled()
         {
+            $this->expectException(\Exception::class);
+
             $options = [
                 'type' => 'text',
                 'prototype' => false
@@ -159,10 +160,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \Exception
          */
         public function it_throws_exception_when_creating_nonexisting_type()
         {
+            $this->expectException(\Exception::class);
+
             $options = [
                 'type' => 'nonexisting'
             ];
@@ -172,10 +174,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \Exception
          */
         public function it_throws_exception_when_data_is_not_iterable()
         {
+            $this->expectException(\Exception::class);
+
             $options = [
                 'type' => 'text',
                 'data' => 'invalid'

--- a/tests/Fields/EntityTypeTest.php
+++ b/tests/Fields/EntityTypeTest.php
@@ -45,10 +45,11 @@ class EntityTypeTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_an_exception_if_model_class_not_provided()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $options = [];
 
         $choice = new EntityType('entity_choice', 'entity', $this->plainForm, $options);

--- a/tests/Filters/FilterResolverTest.php
+++ b/tests/Filters/FilterResolverTest.php
@@ -34,10 +34,11 @@ class FilterResolverTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \Kris\LaravelFormBuilder\Filters\Exception\InvalidInstanceException
      */
     public function it_throws_an_exception_if_object_is_not_instance_of_filterinterface()
     {
+        $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\InvalidInstanceException::class);
+
         $invalidFilterObj = new stdClass();
         $resolver = $this->filtersResolver;
         $resolver::instance($invalidFilterObj);
@@ -45,10 +46,11 @@ class FilterResolverTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \Kris\LaravelFormBuilder\Filters\Exception\UnableToResolveFilterException
      */
     public function it_throws_an_exception_if_filter_cant_be_resolved()
     {
+        $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\UnableToResolveFilterException::class);
+
         $invalidFilterClass = "\\Test\\Not\\Existing\\Class\\";
         $resolver = $this->filtersResolver;
         $resolver::instance($invalidFilterClass);

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -104,10 +104,10 @@ namespace {
 
         /**
          * @test
-         * @expectedException \InvalidArgumentException
          */
         public function it_throws_exception_if_child_form_is_not_valid_class()
         {
+            $this->expectException(\InvalidArgumentException::class);
             $this->plainForm->add('song', 'form', [
                 'class' => 'nonvalid'
             ]);
@@ -115,10 +115,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \InvalidArgumentException
          */
         public function it_throws_exception_if_child_form_class_is_not_passed()
         {
+            $this->expectException(\InvalidArgumentException::class);
+
             $this->plainForm->add('song', 'form', [
                 'class' => null
             ]);
@@ -126,10 +127,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \InvalidArgumentException
          */
         public function it_throws_exception_if_child_form_class_is_not_valid_format()
         {
+            $this->expectException(\InvalidArgumentException::class);
+
             $this->plainForm->add('song', 'form', [
                 'class' => 1
             ]);
@@ -156,6 +158,8 @@ namespace {
             $formBuilder = new FormBuilder($this->app, $formHelper, $this->app['events']);
 
             $formBuilder->create('NamespacedDummyForm');
+
+            $this->assertNotThrown();
         }
 
     }

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -75,7 +75,7 @@ abstract class FormBuilderTestCase extends TestCase {
      */
     protected $filtersResolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -96,7 +96,7 @@ abstract class FormBuilderTestCase extends TestCase {
         $this->filtersResolver = new FilterResolver();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->view = null;
         $this->request = null;
@@ -141,5 +141,10 @@ abstract class FormBuilderTestCase extends TestCase {
         return [
             'Acme' => 'Kris\LaravelFormBuilder\Facades\FormBuilder'
         ];
+    }
+
+    protected function assertNotThrown(): void
+    {
+        $this->assertTrue(true);
     }
 }

--- a/tests/FormBuilderValidationTest.php
+++ b/tests/FormBuilderValidationTest.php
@@ -10,7 +10,7 @@ namespace {
 
     class FormBuilderValidationTest extends FormBuilderTestCase
     {
-        public function setUp()
+        public function setUp(): void
         {
             parent::setUp();
             $this->app

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -53,15 +53,23 @@ class FormHelperTest extends FormBuilderTestCase
         ];
 
         $sourceOptionsForAppending = [
-            '+rules' => ['rule2', 'new_rule1', 'new_rule2'],
+            '+rules' => ['rule2', 'new_rule1', 'new_rule2', 'new_rule3|new_rule4'],
         ];
 
         $expectedForAppending = [
-            'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2'],
+            'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2', 'new_rule3', 'new_rule4'],
         ];
 
         $this->assertEquals($expectedForAppending, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForAppending));
         $this->assertEquals($expectedForReplacing, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForReplacing));
+    }
+
+    /** @test */
+    public function it_normalize_rules_properly()
+    {
+        $this->assertEquals(['rule1', 'rule2', 'rule3', 'rule4', 'rule5'], $this->formHelper->normalizeRules(['rule1', 'rule2', 'rule3|rule4', 'rule5']));
+        $this->assertEquals(['rule1', 'rule2', 'rule3'], $this->formHelper->normalizeRules('rule1|rule2|rule3'));
+        $this->assertEquals(['rule1', 'rule2', 'rule3', 'new_rule'], $this->formHelper->normalizeRules(['rule1|rule2|rule3', 'rule1', 'rule2', 'new_rule']));
     }
 
     /** @test */

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -38,30 +38,21 @@ class FormHelperTest extends FormBuilderTestCase
     }
 
     /** @test */
-    public function it_merges_rules_properly()
+    public function it_appends_rules_properly()
     {
-        $targetOptions = [
+        $defaultOptions = [
             'rules' => ['rule1', 'rule2'],
         ];
 
-        $sourceOptionsForReplacing = [
-            'rules' => ['replaced_rule'],
+        $sourceOptions = [
+            'rules_append' => ['rule2', 'new_rule1', 'new_rule2', 'new_rule3|new_rule4'],
         ];
 
-        $expectedForReplacing = [
-            'rules' => ['replaced_rule'],
-        ];
-
-        $sourceOptionsForAppending = [
-            '+rules' => ['rule2', 'new_rule1', 'new_rule2', 'new_rule3|new_rule4'],
-        ];
-
-        $expectedForAppending = [
+        $expected = [
             'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2', 'new_rule3', 'new_rule4'],
         ];
 
-        $this->assertEquals($expectedForAppending, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForAppending));
-        $this->assertEquals($expectedForReplacing, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForReplacing));
+        $this->assertEquals($expected, $this->formHelper->mergeOptions($defaultOptions, $sourceOptions));
     }
 
     /** @test */

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -38,6 +38,33 @@ class FormHelperTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_merges_rules_properly()
+    {
+        $targetOptions = [
+            'rules' => ['rule1', 'rule2'],
+        ];
+
+        $sourceOptionsForReplacing = [
+            'rules' => ['replaced_rule'],
+        ];
+
+        $expectedForReplacing = [
+            'rules' => ['replaced_rule'],
+        ];
+
+        $sourceOptionsForAppending = [
+            '+rules' => ['rule2', 'new_rule1', 'new_rule2'],
+        ];
+
+        $expectedForAppending = [
+            'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2'],
+        ];
+
+        $this->assertEquals($expectedForAppending, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForAppending));
+        $this->assertEquals($expectedForReplacing, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForReplacing));
+    }
+
+    /** @test */
     public function it_gets_proper_class_for_specific_field_type()
     {
         $input = $this->formHelper->getFieldType('text');

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -38,32 +38,6 @@ class FormHelperTest extends FormBuilderTestCase
     }
 
     /** @test */
-    public function it_appends_rules_properly()
-    {
-        $defaultOptions = [
-            'rules' => ['rule1', 'rule2'],
-        ];
-
-        $sourceOptions = [
-            'rules_append' => ['rule2', 'new_rule1', 'new_rule2', 'new_rule3|new_rule4'],
-        ];
-
-        $expected = [
-            'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2', 'new_rule3', 'new_rule4'],
-        ];
-
-        $this->assertEquals($expected, $this->formHelper->mergeOptions($defaultOptions, $sourceOptions));
-    }
-
-    /** @test */
-    public function it_normalize_rules_properly()
-    {
-        $this->assertEquals(['rule1', 'rule2', 'rule3', 'rule4', 'rule5'], $this->formHelper->normalizeRules(['rule1', 'rule2', 'rule3|rule4', 'rule5']));
-        $this->assertEquals(['rule1', 'rule2', 'rule3'], $this->formHelper->normalizeRules('rule1|rule2|rule3'));
-        $this->assertEquals(['rule1', 'rule2', 'rule3', 'new_rule'], $this->formHelper->normalizeRules(['rule1|rule2|rule3', 'rule1', 'rule2', 'new_rule']));
-    }
-
-    /** @test */
     public function it_gets_proper_class_for_specific_field_type()
     {
         $input = $this->formHelper->getFieldType('text');
@@ -97,10 +71,11 @@ class FormHelperTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_InvalidArgumentException_for_non_existing_field_type()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->formHelper->getFieldType('nonexisting');
     }
 
@@ -166,19 +141,21 @@ class FormHelperTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_InvalidArgumentException_for_empty_field_name()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->formHelper->checkFieldName('', get_class($this));
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_InvalidArgumentException_for_reserved_field_names()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->formHelper->checkFieldName('save', get_class($this));
     }
 }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -68,7 +68,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertTrue($isValid);
 
         $this->assertEquals(
-            ['name' => 'required|min:5', 'description' => 'max:10'],
+            ['name' => ['required', 'min:5'], 'description' => ['max:10']],
             $this->plainForm->getRules()
         );
     }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -277,10 +277,11 @@ class FormTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      * */
     public function it_throws_exception_when_errors_requested_from_non_validated_form()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm
             ->add('name', 'text', [
                 'rules' => 'required|min:5'
@@ -527,11 +528,12 @@ class FormTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
      public function it_throws_exception_when_rendering_until_nonexisting_field()
      {
-        $this->plainForm
+         $this->expectException(\InvalidArgumentException::class);
+
+         $this->plainForm
             ->add('gender', 'select')
             ->add('name', 'text');
 
@@ -541,19 +543,21 @@ class FormTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_prevents_adding_fields_with_same_name()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->add('name', 'text')->add('name', 'textarea');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_if_field_name_is_reserved()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->add('save', 'submit');
     }
 
@@ -579,6 +583,7 @@ class FormTest extends FormBuilderTestCase
         }
 
         if ($exceptionThrown) {
+            $this->assertTrue($exceptionThrown);
             return;
         }
 
@@ -650,6 +655,8 @@ class FormTest extends FormBuilderTestCase
         ];
 
         $this->plainForm->renderForm($formOptions, true, true, true);
+
+        $this->assertNotThrown();
     }
 
     /** @test */
@@ -675,6 +682,8 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->gender->render();
 
         $this->plainForm->renderRest();
+
+        $this->assertNotThrown();
     }
 
     /** @test */
@@ -890,28 +899,31 @@ class FormTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_when_adding_field_with_invalid_name()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->add('', 'text');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_when_adding_field_with_invalid_type()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->add('name', '');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_prevents_adding_duplicate_custom_type()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->addCustomField('datetime', 'Some\\Namespace\\DatetimeType');
 
         $this->plainForm->addCustomField('datetime', 'Some\\Namespace\\DateType');
@@ -1129,4 +1141,5 @@ class FormTest extends FormBuilderTestCase
 
         $this->assertEquals('TEST', $this->request['test_field']);
     }
+
 }

--- a/tests/RulesParserTest.php
+++ b/tests/RulesParserTest.php
@@ -9,7 +9,7 @@ class RulesParserTest extends FormBuilderTestCase
      */
     protected $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $field = new InputType('address', 'text', $this->plainForm);


### PR DESCRIPTION
`\Kris\LaravelFormBuilder\FormHelper::mergeOptions` merges options with `rules` option behavior incorrectly. It should replace the rules entirely or just appends new rules. 
The current strategy may cause the merged rules duplicated, and has no way to "replace" the default rules entirely.