### PR TITLE
Fix exception thrown if `formOptions` contains any non-string value.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -47,7 +47,8 @@ class Form
      */
     protected $formOptions = [
         'method' => 'GET',
-        'url' => null
+        'url' => null,
+        'attr' => [],
     ];
 
     /**
@@ -947,7 +948,9 @@ class Form
      */
     protected function render($options, $fields, $showStart, $showFields, $showEnd)
     {
-        $formOptions = $this->formHelper->mergeOptions($this->formOptions, $options);
+        $formOptions = $this->buildFormOptionsForFormBuilder(
+            $this->formHelper->mergeOptions($this->formOptions, $options)
+        );
 
         $this->setupNamedModel();
 
@@ -961,6 +964,21 @@ class Form
             ->with('form', $this)
             ->render();
     }
+
+    /**
+     * @param $formOptions
+     * @return array
+     */
+    protected function buildFormOptionsForFormBuilder($formOptions)
+    {
+        $reserved = ['method', 'url', 'route', 'action', 'files'];
+        $formAttributes = Arr::get($formOptions, 'attr', []);
+
+        return array_merge(
+            $formAttributes, Arr::only($formOptions, $reserved)
+        );
+    }
+
 
     /**
      * Get template from options if provided, otherwise fallback to config.

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -974,6 +974,13 @@ class Form
         $reserved = ['method', 'url', 'route', 'action', 'files'];
         $formAttributes = Arr::get($formOptions, 'attr', []);
 
+        // move string value to `attr` to maintain backward compatibility
+        foreach ($formOptions as $key => $formOption) {
+            if (!in_array($formOption, $reserved) && is_string($formOption)) {
+                $formAttributes[$key] = $formOption;
+            }
+        }
+
         return array_merge(
             $formAttributes, Arr::only($formOptions, $reserved)
         );

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -340,13 +340,15 @@ class Form
     /**
      * Remove field with specified name from the form.
      *
-     * @param $name
+     * @param string|string[] $names
      * @return $this
      */
-    public function remove($name)
+    public function remove($names)
     {
-        if ($this->has($name)) {
-            unset($this->fields[$name]);
+        foreach (is_array($names) ? $names : func_get_args() as $name) {
+            if ($this->has($name)) {
+                unset($this->fields[$name]);
+            }
         }
 
         return $this;

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -570,11 +570,10 @@ class FormTest extends FormBuilderTestCase
     /** @test */
     public function it_can_set_form_options_with_array_of_options()
     {
-
         $options = [
             'method' => 'POST',
             'url' => '/url/1',
-            'class' => 'form-container',
+            'attr' => ['class' => 'form-container'],
             'model' => $this->model
         ];
 
@@ -602,7 +601,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->setName('test_name');
 
         $this->assertEquals(
-            ['method' => 'DELETE', 'url' => '/posts/all'],
+            ['method' => 'DELETE', 'url' => '/posts/all', 'attr' => []],
             $this->plainForm->getFormOptions()
         );
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -448,11 +448,12 @@ class FormTest extends FormBuilderTestCase
 
         $this->assertTrue($this->plainForm->has('name'));
 
-        $this->plainForm->remove('name');
+        $this->plainForm->remove('name', 'description');
 
-        $this->assertEquals(2, count($this->plainForm->getFields()));
+        $this->assertEquals(1, count($this->plainForm->getFields()));
 
         $this->assertFalse($this->plainForm->has('name'));
+        $this->assertFalse($this->plainForm->has('description'));
     }
 
     /** @test */

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -624,13 +624,14 @@ class FormTest extends FormBuilderTestCase
     /** @test */
     public function it_renders_the_form()
     {
-        $options = [
+        $formOptions = [
             'method' => 'POST',
             'url' => '/someurl',
-            'class' => 'has-error'
+            'class' => 'has-error',
+            'array_option' => ['foo' => 'bar'],
         ];
 
-        $this->plainForm->renderForm($options, true, true, true);
+        $this->plainForm->renderForm($formOptions, true, true, true);
     }
 
     /** @test */


### PR DESCRIPTION
## Issue

When rendering the form with `$formOptions` contains any non-string value like

```php
class MyForm extends BaseForm
{
    protected $formOptions = [
        'foo' => ['bar'], // array value
    ];
}
```

Template:
```php
// This will throw an exception.
<?= Form::open($formOptions) ?>
```

## Solution
Move form attributes to `$formOptions['attr']`, only pass `$formOptions['attr']` and reserved options to the view.

After this PR:
```php
// in template the `foo` was removed from `$formOptions`, 
// so the following code won't throw exception.
<?= Form::open($formOptions) ?>

// but we can still access the original option 
// by calling `$form->getFormOption('foo')`
```

