### PR TITLE
Add a `ContainerType` field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 coverage
 *.taskpaper
 NOTES.md
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=5.6.0",
         "laravelcollective/html": "5.*|^6.0",
         "illuminate/database": "5.*@dev|^6.0",
         "illuminate/validation": "5.*@dev|^6.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.0",
         "laravelcollective/html": "5.*|^6.0",
         "illuminate/database": "5.*@dev|^6.0",
         "illuminate/validation": "5.*@dev|^6.0"

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,13 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
-        "laravelcollective/html": "5.*|^6.0",
-        "illuminate/database": "5.*@dev|^6.0",
-        "illuminate/validation": "5.*@dev|^6.0"
+        "php": ">=7.1",
+        "laravelcollective/html": "5.6.*|^6.0",
+        "illuminate/database": "5.6.*@dev|^6.0",
+        "illuminate/validation": "5.6.*@dev|^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
-        "orchestra/testbench": "~3.4"
+        "orchestra/testbench": "~3.6"
     },
     "extra": {
         "branch-alias": {

--- a/src/Kris/LaravelFormBuilder/Fields/ContainerType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ContainerType.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Kris\LaravelFormBuilder\Fields;
+
+class ContainerType extends ParentType
+{
+    protected function getTemplate()
+    {
+        return 'container';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getDefaults()
+    {
+        return [
+            'fields' => [],
+            'container_class' => 'form-group',
+        ];
+    }
+
+    /**
+     * @return mixed|void
+     * @throws \InvalidArgumentException
+     */
+    protected function createChildren()
+    {
+        $this->children = [];
+        $fields = $this->getOption('fields');
+        $requiredOptions = ['type', 'name'];
+
+        foreach ($fields as $field) {
+            foreach ($requiredOptions as $requiredOption) {
+                if (empty($field[$requiredOption])) {
+                    throw new \InvalidArgumentException("Fields field [{$this->name}] requires [{$requiredOption}] option");
+                }
+            }
+
+            $parentName = $this->parent->getName();
+            $rawName = $field['name'];
+            $name = $parentName ? "{$parentName}[{$rawName}]" : $rawName;
+            $options = $this->formHelper->mergeOptions($field['options'] ?? [], ['attr' => ['id' => $name]]);
+            $type = $field['type'];
+            $fieldType = $this->formHelper->getFieldType($type);
+            $field = new $fieldType($name, $type, $this->parent, $options);
+            $value = $this->getModelValueAttribute($this->parent->getModel(), $rawName);
+            $field->setValue($value);
+            $this->children[$rawName] = $field;
+        }
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    public function getAllAttributes()
+    {
+        return $this->formHelper->mergeAttributes($this->children);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getValidationRules()
+    {
+        return $this->formHelper->mergeFieldsRules($this->children);
+    }
+}

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Arr;
 use Kris\LaravelFormBuilder\Events\AfterFieldCreation;
 use Kris\LaravelFormBuilder\Events\AfterFormValidation;
 use Kris\LaravelFormBuilder\Events\BeforeFormValidation;
+use Kris\LaravelFormBuilder\Fields\ContainerType;
 use Kris\LaravelFormBuilder\Fields\FormField;
 use Kris\LaravelFormBuilder\Filters\FilterResolver;
 
@@ -458,6 +459,7 @@ class Form
      *
      * @param string $name
      * @return FormField
+     * @throws \InvalidArgumentException
      */
     public function getField($name)
     {
@@ -465,8 +467,37 @@ class Form
             return $this->fields[$name];
         }
 
+        if ($result = $this->findField($name, $this->fields)) {
+            return $result;
+        }
+
         $this->fieldDoesNotExist($name);
     }
+
+    /**
+     * Find field by name including the children of ContainerType field.
+     * @param $name
+     * @param $fields
+     * @return FormField|null
+     */
+    protected function findField($name, $fields)
+    {
+        foreach ($fields as $thisFieldName => $field) {
+            if ($thisFieldName === $name) {
+                return $field;
+            }
+
+            if ($field instanceof ContainerType) {
+                $result = $this->findField($name, $field->getChildren());
+                if ($result) {
+                    return $result;
+                }
+            }
+        }
+
+        return null;
+    }
+
 
     public function getErrorBag()
     {

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -130,13 +130,23 @@ class FormHelper
     /**
      * Merge options array.
      *
-     * @param array $first
-     * @param array $second
+     * @param array $targetOptions
+     * @param array $sourceOptions
      * @return array
      */
-    public function mergeOptions(array $first, array $second)
+    public function mergeOptions(array $targetOptions, array $sourceOptions)
     {
-        return array_replace_recursive($first, $second);
+        if (array_key_exists('+rules', $sourceOptions)) {
+            $mergedRules = array_values(array_unique(array_merge($targetOptions['rules'] ?? [], $sourceOptions['+rules'])));
+            $targetOptions['rules'] = $mergedRules;
+            unset($sourceOptions['+rules']);
+        }
+
+        if (array_key_exists('rules', $targetOptions) && array_key_exists('rules', $sourceOptions)) {
+            unset($targetOptions['rules']);
+        }
+
+        return array_replace_recursive($targetOptions, $sourceOptions);
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -136,55 +136,9 @@ class FormHelper
      */
     public function mergeOptions(array $targetOptions, array $sourceOptions)
     {
-        // Normalize rules
-        if (array_key_exists('rules_append', $sourceOptions)) {
-            $sourceOptions['rules_append'] = $this->normalizeRules($sourceOptions['rules_append']);
-        }
-
-        if (array_key_exists('rules', $sourceOptions)) {
-            $sourceOptions['rules'] = $this->normalizeRules($sourceOptions['rules']);
-        }
-
-        if (array_key_exists('rules', $targetOptions)) {
-            $targetOptions['rules'] = $this->normalizeRules($targetOptions['rules']);
-        }
-
-
-        // Append rules
-        if ($rulesToBeAppended = Arr::pull($sourceOptions, 'rules_append')) {
-            $mergedRules = array_values(array_unique(array_merge($targetOptions['rules'], $rulesToBeAppended)));
-            $targetOptions['rules'] = $mergedRules;
-        }
-
         return array_replace_recursive($targetOptions, $sourceOptions);
     }
 
-    /**
-     * Normalize the the given rule expression to an array.
-     * @param mixed $rules
-     * @return array
-     */
-    public function normalizeRules($rules)
-    {
-        if (empty($rules)) {
-            return [];
-        }
-
-        if (is_string($rules)) {
-            return explode('|', $rules);
-        }
-
-        if (is_array($rules)) {
-            $normalizedRules = [];
-            foreach ($rules as $rule) {
-                $normalizedRules[] = $this->normalizeRules($rule);
-            }
-
-            return array_values(array_unique(Arr::flatten($normalizedRules)));
-        }
-
-        return $rules;
-    }
 
     /**
      * Get proper class for field type.

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -137,8 +137,8 @@ class FormHelper
     public function mergeOptions(array $targetOptions, array $sourceOptions)
     {
         // Normalize rules
-        if (array_key_exists('+rules', $sourceOptions)) {
-            $sourceOptions['+rules'] = $this->normalizeRules($sourceOptions['+rules']);
+        if (array_key_exists('rules_append', $sourceOptions)) {
+            $sourceOptions['rules_append'] = $this->normalizeRules($sourceOptions['rules_append']);
         }
 
         if (array_key_exists('rules', $sourceOptions)) {
@@ -151,15 +151,9 @@ class FormHelper
 
 
         // Append rules
-        if ($rulesToBeAppended = Arr::pull($sourceOptions, '+rules')) {
+        if ($rulesToBeAppended = Arr::pull($sourceOptions, 'rules_append')) {
             $mergedRules = array_values(array_unique(array_merge($targetOptions['rules'], $rulesToBeAppended)));
             $targetOptions['rules'] = $mergedRules;
-        }
-
-
-        // Replace rules
-        if (array_key_exists('rules', $targetOptions) && array_key_exists('rules', $sourceOptions)) {
-            unset($targetOptions['rules']);
         }
 
         return array_replace_recursive($targetOptions, $sourceOptions);

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -79,7 +79,8 @@ class FormHelper
         'entity'         => 'EntityType',
         'collection'     => 'CollectionType',
         'repeated'       => 'RepeatedType',
-        'static'         => 'StaticType'
+        'container'      => 'ContainerType',
+        'static'         => 'StaticType',
     ];
 
     /**

--- a/src/Kris/LaravelFormBuilder/RulesParser.php
+++ b/src/Kris/LaravelFormBuilder/RulesParser.php
@@ -595,14 +595,6 @@ class RulesParser
      */
     protected function getRulesAsArray($rules)
     {
-        $rulesArray = (is_string($rules)) ? explode('|', $rules) : $rules;
-
-        return array_map(function ($rule) {
-            if ($rule instanceof \Closure) {
-                return $rule($this->field->getNameKey());
-            }
-
-            return $rule;
-        }, $rulesArray);
+        return is_string($rules) ? explode('|', $rules) : (array)$rules;
     }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -37,6 +37,7 @@ return [
     'repeated'      => 'laravel-form-builder::repeated',
     'child_form'    => 'laravel-form-builder::child_form',
     'collection'    => 'laravel-form-builder::collection',
+    'container'     => 'laravel-form-builder::container',
     'static'        => 'laravel-form-builder::static',
 
     // Remove the laravel-form-builder:: prefix above when using template_prefix

--- a/src/views/container.php
+++ b/src/views/container.php
@@ -1,0 +1,25 @@
+<?php if ($showLabel || $showField): ?>
+    <?php if ($options['wrapper'] !== false): ?>
+        <div <?= $options['wrapperAttrs'] ?>>
+    <?php endif; ?>
+
+    <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
+        <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php endif; ?>
+
+    <?php if ($showField): ?>
+        <div class="<?= $options['container_class'] ?? '' ?>">
+            <?php foreach ((array)$options['children'] as $child): ?>
+                <?= $child->render() ?>
+            <?php endforeach; ?>
+        </div>
+
+
+        <?php include 'help_block.php' ?>
+        <?php include 'errors.php' ?>
+    <?php endif; ?>
+
+    <?php if ($options['wrapper'] !== false): ?>
+        </div>
+    <?php endif; ?>
+<?php endif; ?>

--- a/tests/Console/FormGeneratorTest.php
+++ b/tests/Console/FormGeneratorTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Kris\LaravelFormBuilder\Console\FormGenerator;
+use PHPUnit\Framework\TestCase;
 
-class FormGeneratorTest extends PHPUnit_Framework_TestCase
+class FormGeneratorTest extends TestCase
 {
 
     /**
@@ -10,7 +11,7 @@ class FormGeneratorTest extends PHPUnit_Framework_TestCase
      */
     protected $formGenerator;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->formGenerator = new FormGenerator();
     }

--- a/tests/Fields/ButtonTypeTest.php
+++ b/tests/Fields/ButtonTypeTest.php
@@ -87,6 +87,6 @@ class ButtonTypeTest extends FormBuilderTestCase
         $renderedView = $button->render();
 
         $this->assertEquals($expectedOptions, $button->getOptions());
-        $this->assertContains('<input', $renderedView);
+        $this->assertStringContainsString('<input', $renderedView);
     }
 }

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -141,10 +141,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \Exception
          */
         public function it_throws_exception_when_requesting_prototype_while_it_is_disabled()
         {
+            $this->expectException(\Exception::class);
+
             $options = [
                 'type' => 'text',
                 'prototype' => false
@@ -159,10 +160,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \Exception
          */
         public function it_throws_exception_when_creating_nonexisting_type()
         {
+            $this->expectException(\Exception::class);
+
             $options = [
                 'type' => 'nonexisting'
             ];
@@ -172,10 +174,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \Exception
          */
         public function it_throws_exception_when_data_is_not_iterable()
         {
+            $this->expectException(\Exception::class);
+
             $options = [
                 'type' => 'text',
                 'data' => 'invalid'

--- a/tests/Fields/ContainerTypeTest.php
+++ b/tests/Fields/ContainerTypeTest.php
@@ -1,0 +1,152 @@
+<?php
+
+use Kris\LaravelFormBuilder\Fields\ContainerType;
+
+class ContainerTypeTest extends FormBuilderTestCase
+{
+    /** @test */
+    public function it_adds_children_fields()
+    {
+        $containerType = $this->buildContainerType();
+
+        $this->assertEquals(2, count($containerType->getChildren()));
+    }
+
+    /** @test */
+    public function it_render_properly()
+    {
+        $this->buildContainerType()->render();
+        $this->assertNotThrown();
+    }
+
+    /** @test */
+    public function it_has_the_proper_field_name()
+    {
+        $containerType = $this->buildContainerType();
+        $children = $containerType->getChildren();
+
+        $this->assertEquals('select_field_1', $children['select_field_1']->getName());
+        $this->assertEquals('select_field_2', $children['select_field_2']->getName());
+
+
+        // within a named form.
+        $formName = 'Foo';
+        $this->plainForm->setName($formName);
+
+        $containerType = $this->buildContainerType();
+        $children = $containerType->getChildren();
+
+        $this->assertEquals("{$formName}[select_field_1]", $children['select_field_1']->getName());
+        $this->assertEquals("{$formName}[select_field_2]", $children['select_field_2']->getName());
+    }
+
+    /** @test */
+    public function its_children_fields_can_be_found_from_parent_form()
+    {
+        $childFieldName = 'select_field_1';
+
+        $this->plainForm->add('container_field', 'container', [
+            'fields' => [
+                [
+                    'type' => 'select',
+                    'name' => $childFieldName,
+                ]
+            ]
+        ]);
+
+        $childField = $this->plainForm->getField($childFieldName);
+
+        $this->assertEquals($childFieldName, $childField->getRealName());
+    }
+
+    /** @test */
+    public function it_has_value_set_given_from_parent_model()
+    {
+        $childFieldName = 'select_field_1';
+        $childFieldValue = 'Foo';
+        $formOptions = [
+            'model' => [
+                $childFieldName => $childFieldValue
+            ]
+        ];
+
+        $form = $this->formBuilder->plain($formOptions)->add('container_field', 'container', [
+            'fields' => [
+                [
+                    'type' => 'select',
+                    'name' => $childFieldName,
+                ]
+            ]
+        ]);
+
+        $childField = $form->getField($childFieldName);
+
+        $this->assertEquals($childFieldValue, $childField->getValue());
+    }
+
+    /** @test */
+    public function it_get_the_proper_rules()
+    {
+        $containerType = $this->buildContainerType();
+        $rules = $containerType->getValidationRules()->getRules();
+
+        $this->assertEquals(['email'], $rules['select_field_1']);
+        $this->assertEquals(['date'], $rules['select_field_2']);
+    }
+
+    /** @test */
+    public function it_get_the_proper_attributes()
+    {
+        $containerType = $this->buildContainerType();
+        $attributes = $containerType->getAllAttributes();
+
+        $this->assertEquals(['select_field_1', 'select_field_2'], $attributes);
+    }
+
+    /** @test */
+    public function it_throws_if_required_parameter_not_given()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->buildContainerType([
+            'fields' => [
+                [
+                    'type' => null,
+                ],
+                [
+                    'name' => null,
+                ]
+            ]
+        ]);
+    }
+
+    private function buildContainerType(array $options = []): ContainerType
+    {
+        $fields = [
+            [
+                'type' => 'select',
+                'name' => 'select_field_1',
+                'options' => [
+                    'label' => 'Label for select_field_1',
+                    'choices' => ['foo' => 'Foo Label'],
+                    'rules' => ['email'],
+                ],
+            ],
+            [
+                'type' => 'select',
+                'name' => 'select_field_2',
+                'options' => [
+                    'label' => 'Label for select_field_2',
+                    'choices' => ['bar' => 'Bar Label'],
+                    'rules' => ['date'],
+                ],
+            ],
+        ];
+
+        $defaultOptions = [
+            'fields' => $fields,
+        ];
+
+        return new ContainerType('container_field', 'container', $this->plainForm, $this->formHelper->mergeOptions($defaultOptions, $options));
+    }
+
+}

--- a/tests/Fields/EntityTypeTest.php
+++ b/tests/Fields/EntityTypeTest.php
@@ -45,10 +45,11 @@ class EntityTypeTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_an_exception_if_model_class_not_provided()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $options = [];
 
         $choice = new EntityType('entity_choice', 'entity', $this->plainForm, $options);

--- a/tests/Filters/FilterResolverTest.php
+++ b/tests/Filters/FilterResolverTest.php
@@ -34,10 +34,11 @@ class FilterResolverTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \Kris\LaravelFormBuilder\Filters\Exception\InvalidInstanceException
      */
     public function it_throws_an_exception_if_object_is_not_instance_of_filterinterface()
     {
+        $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\InvalidInstanceException::class);
+
         $invalidFilterObj = new stdClass();
         $resolver = $this->filtersResolver;
         $resolver::instance($invalidFilterObj);
@@ -45,10 +46,11 @@ class FilterResolverTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \Kris\LaravelFormBuilder\Filters\Exception\UnableToResolveFilterException
      */
     public function it_throws_an_exception_if_filter_cant_be_resolved()
     {
+        $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\UnableToResolveFilterException::class);
+
         $invalidFilterClass = "\\Test\\Not\\Existing\\Class\\";
         $resolver = $this->filtersResolver;
         $resolver::instance($invalidFilterClass);

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -104,10 +104,10 @@ namespace {
 
         /**
          * @test
-         * @expectedException \InvalidArgumentException
          */
         public function it_throws_exception_if_child_form_is_not_valid_class()
         {
+            $this->expectException(\InvalidArgumentException::class);
             $this->plainForm->add('song', 'form', [
                 'class' => 'nonvalid'
             ]);
@@ -115,10 +115,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \InvalidArgumentException
          */
         public function it_throws_exception_if_child_form_class_is_not_passed()
         {
+            $this->expectException(\InvalidArgumentException::class);
+
             $this->plainForm->add('song', 'form', [
                 'class' => null
             ]);
@@ -126,10 +127,11 @@ namespace {
 
         /**
          * @test
-         * @expectedException \InvalidArgumentException
          */
         public function it_throws_exception_if_child_form_class_is_not_valid_format()
         {
+            $this->expectException(\InvalidArgumentException::class);
+
             $this->plainForm->add('song', 'form', [
                 'class' => 1
             ]);
@@ -156,6 +158,8 @@ namespace {
             $formBuilder = new FormBuilder($this->app, $formHelper, $this->app['events']);
 
             $formBuilder->create('NamespacedDummyForm');
+
+            $this->assertNotThrown();
         }
 
     }

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -75,7 +75,7 @@ abstract class FormBuilderTestCase extends TestCase {
      */
     protected $filtersResolver;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -96,7 +96,7 @@ abstract class FormBuilderTestCase extends TestCase {
         $this->filtersResolver = new FilterResolver();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         $this->view = null;
         $this->request = null;
@@ -141,5 +141,10 @@ abstract class FormBuilderTestCase extends TestCase {
         return [
             'Acme' => 'Kris\LaravelFormBuilder\Facades\FormBuilder'
         ];
+    }
+
+    protected function assertNotThrown(): void
+    {
+        $this->assertTrue(true);
     }
 }

--- a/tests/FormBuilderValidationTest.php
+++ b/tests/FormBuilderValidationTest.php
@@ -10,7 +10,7 @@ namespace {
 
     class FormBuilderValidationTest extends FormBuilderTestCase
     {
-        public function setUp()
+        public function setUp(): void
         {
             parent::setUp();
             $this->app

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -53,15 +53,23 @@ class FormHelperTest extends FormBuilderTestCase
         ];
 
         $sourceOptionsForAppending = [
-            '+rules' => ['rule2', 'new_rule1', 'new_rule2'],
+            '+rules' => ['rule2', 'new_rule1', 'new_rule2', 'new_rule3|new_rule4'],
         ];
 
         $expectedForAppending = [
-            'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2'],
+            'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2', 'new_rule3', 'new_rule4'],
         ];
 
         $this->assertEquals($expectedForAppending, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForAppending));
         $this->assertEquals($expectedForReplacing, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForReplacing));
+    }
+
+    /** @test */
+    public function it_normalize_rules_properly()
+    {
+        $this->assertEquals(['rule1', 'rule2', 'rule3', 'rule4', 'rule5'], $this->formHelper->normalizeRules(['rule1', 'rule2', 'rule3|rule4', 'rule5']));
+        $this->assertEquals(['rule1', 'rule2', 'rule3'], $this->formHelper->normalizeRules('rule1|rule2|rule3'));
+        $this->assertEquals(['rule1', 'rule2', 'rule3', 'new_rule'], $this->formHelper->normalizeRules(['rule1|rule2|rule3', 'rule1', 'rule2', 'new_rule']));
     }
 
     /** @test */

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -38,30 +38,21 @@ class FormHelperTest extends FormBuilderTestCase
     }
 
     /** @test */
-    public function it_merges_rules_properly()
+    public function it_appends_rules_properly()
     {
-        $targetOptions = [
+        $defaultOptions = [
             'rules' => ['rule1', 'rule2'],
         ];
 
-        $sourceOptionsForReplacing = [
-            'rules' => ['replaced_rule'],
+        $sourceOptions = [
+            'rules_append' => ['rule2', 'new_rule1', 'new_rule2', 'new_rule3|new_rule4'],
         ];
 
-        $expectedForReplacing = [
-            'rules' => ['replaced_rule'],
-        ];
-
-        $sourceOptionsForAppending = [
-            '+rules' => ['rule2', 'new_rule1', 'new_rule2', 'new_rule3|new_rule4'],
-        ];
-
-        $expectedForAppending = [
+        $expected = [
             'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2', 'new_rule3', 'new_rule4'],
         ];
 
-        $this->assertEquals($expectedForAppending, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForAppending));
-        $this->assertEquals($expectedForReplacing, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForReplacing));
+        $this->assertEquals($expected, $this->formHelper->mergeOptions($defaultOptions, $sourceOptions));
     }
 
     /** @test */

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -38,6 +38,33 @@ class FormHelperTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_merges_rules_properly()
+    {
+        $targetOptions = [
+            'rules' => ['rule1', 'rule2'],
+        ];
+
+        $sourceOptionsForReplacing = [
+            'rules' => ['replaced_rule'],
+        ];
+
+        $expectedForReplacing = [
+            'rules' => ['replaced_rule'],
+        ];
+
+        $sourceOptionsForAppending = [
+            '+rules' => ['rule2', 'new_rule1', 'new_rule2'],
+        ];
+
+        $expectedForAppending = [
+            'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2'],
+        ];
+
+        $this->assertEquals($expectedForAppending, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForAppending));
+        $this->assertEquals($expectedForReplacing, $this->formHelper->mergeOptions($targetOptions, $sourceOptionsForReplacing));
+    }
+
+    /** @test */
     public function it_gets_proper_class_for_specific_field_type()
     {
         $input = $this->formHelper->getFieldType('text');

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -38,32 +38,6 @@ class FormHelperTest extends FormBuilderTestCase
     }
 
     /** @test */
-    public function it_appends_rules_properly()
-    {
-        $defaultOptions = [
-            'rules' => ['rule1', 'rule2'],
-        ];
-
-        $sourceOptions = [
-            'rules_append' => ['rule2', 'new_rule1', 'new_rule2', 'new_rule3|new_rule4'],
-        ];
-
-        $expected = [
-            'rules' => ['rule1', 'rule2', 'new_rule1', 'new_rule2', 'new_rule3', 'new_rule4'],
-        ];
-
-        $this->assertEquals($expected, $this->formHelper->mergeOptions($defaultOptions, $sourceOptions));
-    }
-
-    /** @test */
-    public function it_normalize_rules_properly()
-    {
-        $this->assertEquals(['rule1', 'rule2', 'rule3', 'rule4', 'rule5'], $this->formHelper->normalizeRules(['rule1', 'rule2', 'rule3|rule4', 'rule5']));
-        $this->assertEquals(['rule1', 'rule2', 'rule3'], $this->formHelper->normalizeRules('rule1|rule2|rule3'));
-        $this->assertEquals(['rule1', 'rule2', 'rule3', 'new_rule'], $this->formHelper->normalizeRules(['rule1|rule2|rule3', 'rule1', 'rule2', 'new_rule']));
-    }
-
-    /** @test */
     public function it_gets_proper_class_for_specific_field_type()
     {
         $input = $this->formHelper->getFieldType('text');
@@ -97,10 +71,11 @@ class FormHelperTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_InvalidArgumentException_for_non_existing_field_type()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->formHelper->getFieldType('nonexisting');
     }
 
@@ -166,19 +141,21 @@ class FormHelperTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_InvalidArgumentException_for_empty_field_name()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->formHelper->checkFieldName('', get_class($this));
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_InvalidArgumentException_for_reserved_field_names()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->formHelper->checkFieldName('save', get_class($this));
     }
 }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -68,7 +68,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertTrue($isValid);
 
         $this->assertEquals(
-            ['name' => 'required|min:5', 'description' => 'max:10'],
+            ['name' => ['required', 'min:5'], 'description' => ['max:10']],
             $this->plainForm->getRules()
         );
     }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -277,10 +277,11 @@ class FormTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      * */
     public function it_throws_exception_when_errors_requested_from_non_validated_form()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm
             ->add('name', 'text', [
                 'rules' => 'required|min:5'
@@ -527,11 +528,12 @@ class FormTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
      public function it_throws_exception_when_rendering_until_nonexisting_field()
      {
-        $this->plainForm
+         $this->expectException(\InvalidArgumentException::class);
+
+         $this->plainForm
             ->add('gender', 'select')
             ->add('name', 'text');
 
@@ -541,19 +543,21 @@ class FormTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_prevents_adding_fields_with_same_name()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->add('name', 'text')->add('name', 'textarea');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_if_field_name_is_reserved()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->add('save', 'submit');
     }
 
@@ -579,6 +583,7 @@ class FormTest extends FormBuilderTestCase
         }
 
         if ($exceptionThrown) {
+            $this->assertTrue($exceptionThrown);
             return;
         }
 
@@ -650,6 +655,8 @@ class FormTest extends FormBuilderTestCase
         ];
 
         $this->plainForm->renderForm($formOptions, true, true, true);
+
+        $this->assertNotThrown();
     }
 
     /** @test */
@@ -675,6 +682,8 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->gender->render();
 
         $this->plainForm->renderRest();
+
+        $this->assertNotThrown();
     }
 
     /** @test */
@@ -890,28 +899,31 @@ class FormTest extends FormBuilderTestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_when_adding_field_with_invalid_name()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->add('', 'text');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_exception_when_adding_field_with_invalid_type()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->add('name', '');
     }
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
      */
     public function it_prevents_adding_duplicate_custom_type()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->plainForm->addCustomField('datetime', 'Some\\Namespace\\DatetimeType');
 
         $this->plainForm->addCustomField('datetime', 'Some\\Namespace\\DateType');
@@ -1129,4 +1141,5 @@ class FormTest extends FormBuilderTestCase
 
         $this->assertEquals('TEST', $this->request['test_field']);
     }
+
 }

--- a/tests/RulesParserTest.php
+++ b/tests/RulesParserTest.php
@@ -9,7 +9,7 @@ class RulesParserTest extends FormBuilderTestCase
      */
     protected $parser;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         $field = new InputType('address', 'text', $this->plainForm);


### PR DESCRIPTION
This PR adds a `ContainerType` field which solves #572.
It was branched from #577 , so you might only want to see the diff at https://github.com/kristijanhusak/laravel-form-builder/commit/d016cba31cabfded082919f0bebaa8efa106bc06


`ContainerType` field acts as a "container", which means even it has children fields, but it'll make the hierarchy of it's children as same as itself. In other words, the field's attributes and rules are be replaced by its children's ones(similar to `ChildFormType`). With this, users can easily implement `fieldset` or similar things by just specifying a custom template.

## Usage
```php
<?php

namespace App\Forms;

class MyForm extends Form
{
    public function buildForm()
    {
        $this
            ->add('date', 'container', [
                'label' => 'DATE',
                'fields' => [
                    [
                        'type' => 'date',
                        'name' => 'start_date',
                        'options' => [
                            'label' => false,
                            'rules' => 'required|date|max:255',
                        ],
                    ],
                    [
                        'type' => 'date',
                        'name' => 'end_date',
                        'rules' => 'date|max:255',
                        'options' => [
                            'label' => false,
                            'rules' => 'date|max:255',
                        ],
                    ]
                ],
            ]);
    }
}
```