### PR TITLE
Add support for "allow destroy" to `ChildForm`

### DIFF
--- a/tests/Fields/ChildFormTypeTest.php
+++ b/tests/Fields/ChildFormTypeTest.php
@@ -54,4 +54,35 @@ class ChildFormTypeTest extends FormBuilderTestCase
         $this->assertEquals('different.{name}', $plainChild->getTranslationTemplate());
         $this->assertEquals('test.{name}', $plainParent->getTranslationTemplate());
     }
+
+    /**
+     * @test
+     */
+    public function it_allow_destroy()
+    {
+        $parentForm = $this->formBuilder->plain([
+            'model' => [
+                'user' => [
+                    'id' => 1,
+                    'email' => 'foo@test.com',
+                    '_destroy'=>true,
+                ]
+            ]
+        ]);
+
+        $childForm = $this->formBuilder->plain()->add('id')->add('email');
+
+        $requiredFieldsForAllowDestroy = ['_destroy', 'id'];
+
+        $parentForm->add('user', 'form', [
+            'class' => $childForm,
+            'allow_destroy' => true,
+            'required_fields_for_allow_destroy' => $requiredFieldsForAllowDestroy
+        ]);
+
+        $childFormFields = $parentForm->getField('user')->getChildren();
+
+        $this->assertEquals($requiredFieldsForAllowDestroy, array_keys($childFormFields));
+        $this->assertArrayNotHasKey('email', $childFormFields);
+    }
 }


### PR DESCRIPTION
Currently `collection` type with `'type' => 'form'` be set can only add child but can not destroy existing ones.

This PR adds an option `allow_destroy`(took the name from [Rails](https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html)) to `ChildForm`.

With `allow_destroy` equals `true`, all fields got removed except the fields given by the `required_fields_for_allow_destroy` option. This can avoid unnecessary validations on the items which are going to be destroyed.