### PR TITLE
Field name as default prototype name for `CollectionType`

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -2,6 +2,7 @@
 
 namespace Kris\LaravelFormBuilder\Fields;
 
+use Illuminate\Support\Str;
 use Illuminate\Support\Collection;
 
 class CollectionType extends ParentType
@@ -31,13 +32,15 @@ class CollectionType extends ParentType
      */
     protected function getDefaults()
     {
+        $prototypeName = Str::camel($this->getRealName());
+
         return [
             'type' => null,
             'options' => ['is_child' => true],
             'prototype' => true,
             'data' => null,
             'property' => 'id',
-            'prototype_name' => '__NAME__',
+            'prototype_name' => "__{$prototypeName}__",
             'empty_row' => true,
             'prefer_input' => false,
         ];

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -629,6 +629,7 @@ abstract class FormField
      */
     protected function setDefaultOptions(array $options = [])
     {
+        $this->options = $options;
         $this->options = $this->formHelper->mergeOptions($this->allDefaults(), $this->getDefaults());
         $this->options = $this->prepareOptions($options);
 

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1109,8 +1109,8 @@ class Form
 
         $dotName = $this->getNameKey();
         $model = $this->formHelper->convertModelToArray($this->getModel());
-        $isCollectionFormModel = (bool) preg_match('/^.*\.\d+$/', $dotName);
-        $isCollectionPrototype = strpos($dotName, '__NAME__') !== false;
+        $isCollectionFormModel = (bool)preg_match('/^.*\.\d+$/', $dotName);
+        $isCollectionPrototype = (bool)preg_match('/__\w+__$/', $dotName);
 
         if (!Arr::get($model, $dotName) && !$isCollectionFormModel && !$isCollectionPrototype) {
             $newModel = [];

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -209,6 +209,22 @@ namespace {
                 $form->dummy_collection->prototype()->title->getValue()
             );
         }
+
+        /**
+         * @test
+         */
+        public function it_sets_up_default_prototype_name()
+        {
+            $options = [
+                'type' => 'form',
+                'options' => [
+                    'class' => Form::class,
+                ]
+            ];
+
+            $collectionField = $this->plainForm->add('foo_bar', 'collection', $options)->foo_bar;
+            $this->assertEquals('__fooBar__', $collectionField->getOption('prototype_name'));
+        }
     }
 
     class DummyEloquentModel extends Model {


### PR DESCRIPTION
Make the field name as default prototype name for `CollectionType`, so we don't need set the prototype name manually whenever we add a collection field.