### PR TITLE
Make ParentType::setOption(s) return $this

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -106,6 +106,8 @@ abstract class ParentType extends FormField
                 $this->children[$key]->setOption($name, $value);
             }
         }
+
+        return $this;
     }
 
     /**
@@ -120,6 +122,8 @@ abstract class ParentType extends FormField
                 $this->children[$key]->setOptions($options);
             }
         }
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
The parent class FormField does this, so ParentType should do, too