### PR TITLE
Added ability to pass attributes to individual options in select/choices

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
@@ -105,7 +105,7 @@ class ChoiceType extends ParentType
             $options = $this->formHelper->mergeOptions(
                 $this->getOption('choice_options'),
                 [
-                    'attr'       => ['id' => $id],
+                    'attr'       => array_merge(['id' => $id], $this->options['option_attributes'][$key] ?? []),
                     'label_attr' => ['for' => $id],
                     'label'      => $choice,
                     'checked'    => in_array($key, (array)$this->options[$this->valueProperty]),

--- a/src/Kris/LaravelFormBuilder/Fields/SelectType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/SelectType.php
@@ -27,8 +27,9 @@ class SelectType extends FormField
     {
         return [
             'choices' => [],
+            'option_attributes' => [],
             'empty_value' => null,
-            'selected' => null
+            'selected' => null,
         ];
     }
 }

--- a/src/Kris/LaravelFormBuilder/Fields/SelectType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/SelectType.php
@@ -29,7 +29,7 @@ class SelectType extends FormField
             'choices' => [],
             'option_attributes' => [],
             'empty_value' => null,
-            'selected' => null,
+            'selected' => null
         ];
     }
 }

--- a/src/views/select.php
+++ b/src/views/select.php
@@ -10,7 +10,7 @@
 
 <?php if ($showField): ?>
     <?php $emptyVal = $options['empty_value'] ? ['' => $options['empty_value']] : null; ?>
-    <?= Form::select($name, (array)$emptyVal + $options['choices'], $options['selected'], $options['attr']) ?>
+    <?= Form::select($name, (array)$emptyVal + $options['choices'], $options['selected'], $options['attr'], $options['option_attributes']) ?>
     <?php include 'help_block.php' ?>
 <?php endif; ?>
 

--- a/tests/Fields/SelectTypeTest.php
+++ b/tests/Fields/SelectTypeTest.php
@@ -39,6 +39,7 @@ class SelectTypeTest extends FormBuilderTestCase
         $expectedOptions['choices'] = $choices;
         $expectedOptions['empty_value'] = 'Select your sex';
         $expectedOptions['selected'] = '1';
+        $expectedOptions['option_attributes'] = [];
 
         $select = new SelectType('sex', 'select', $this->plainForm, $options);
 

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -468,7 +468,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->only('remember', 'name');
 
         $this->assertEquals(2, count($this->plainForm->getFields()));
-        
+
         $this->assertTrue($this->plainForm->has('remember'));
         $this->assertTrue($this->plainForm->has('name'));
         $this->assertFalse($this->plainForm->has('description'));
@@ -1142,4 +1142,55 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('TEST', $this->request['test_field']);
     }
 
+    /** @test */
+    public function it_add_option_attributes_properly()
+    {
+        $config = $this->config;
+
+        $formHelper = new FormHelper($this->view, $this->translator, $config);
+        $formBuilder = new FormBuilder($this->app, $formHelper, $this->eventDispatcher);
+
+        $choices = ['en' => 'English', 'fr' => 'French', 'zh' => 'Chinese'];
+        $optionAttributes = ['zh' => ['disabled' => 'disabled']];
+
+        $form = $formBuilder->plain()
+            ->add('languages_select', 'select', [
+                'choices' => $choices,
+                'option_attributes' => $optionAttributes
+            ])
+            ->add('languages_choice_select', 'choice', [
+                'choices' => $choices,
+                'option_attributes' => $optionAttributes,
+                'expanded' => false,
+                'multiple' => false
+            ])
+            ->add('languages_choice_select_multiple', 'choice', [
+                'choices' => $choices,
+                'option_attributes' => $optionAttributes,
+                'expanded' => false,
+                'multiple' => true
+            ])
+            ->add('languages_choice_checkbox', 'choice', [
+                'choices' => $choices,
+                'option_attributes' => $optionAttributes,
+                'expanded' => true,
+                'multiple' => true
+            ])
+            ->add('languages_choice_radio', 'choice', [
+                'choices' => $choices,
+                'option_attributes' => $optionAttributes,
+                'expanded' => true,
+                'multiple' => false
+            ]);
+
+        $formView = $form->renderForm();
+
+        $this->assertStringContainsString('<option value="zh" disabled="disabled">', $formView);
+        $this->assertStringNotContainsString('<option value="en" disabled="disabled">', $formView);
+        $this->assertStringNotContainsString('<option value="fr" disabled="disabled">', $formView);
+        $this->assertStringContainsString('<input id="languages_choice_checkbox_zh" disabled="disabled" name="languages_choice_checkbox[]" type="checkbox" value="zh">', $formView);
+        $this->assertStringNotContainsString('<input id="languages_choice_checkbox_en" disabled="disabled" name="languages_choice_checkbox[]" type="checkbox" value="en">', $formView);
+        $this->assertStringContainsString('<input id="languages_choice_radio_zh" disabled="disabled" name="languages_choice_radio" type="radio" value="zh">', $formView);
+        $this->assertStringNotContainsString('<input id="languages_choice_radio_en" disabled="disabled" name="languages_choice_radio" type="radio" value="en">', $formView);
+    }
 }


### PR DESCRIPTION
Added ability to pass attributes to individual options in select/choices

For example, I want to disable certain option in my select/choice list
Pass two-dimensional array with 
['option_key' => ['attribute' => 'attribute_value']] into `option_attributes` option.

Inspired by the 5th parameter of LaravelCollective Form::select()
https://github.com/LaravelCollective/html/blob/6.x/src/FormBuilder.php#L614

Example:
```php
<?php

namespace App\Forms;

use Kris\LaravelFormBuilder\Form;

class ExampleForm extends Form
{
    public function buildForm()
    {
        $this->add('languages_select', 'select', [
            'choices' => ['en' => 'English', 'fr' => 'French', 'zh' => 'Chinese'],
            'choice_options' => [
                'wrapper' => ['class' => 'choice-wrapper'],
                'label_attr' => ['class' => 'label-class'],
            ],
            'selected' => ['en'],
            'option_attributes' => ['zh' => ['disabled' => 'disabled']],
            'expanded' => false,
            'multiple' => false
        ]);

        $this->add('languages_choice_select', 'choice', [
            'choices' => ['en' => 'English', 'fr' => 'French', 'zh' => 'Chinese'],
            'choice_options' => [
                'wrapper' => ['class' => 'choice-wrapper'],
                'label_attr' => ['class' => 'label-class'],
            ],
            'selected' => ['en'],
            'option_attributes' => ['zh' => ['disabled' => 'disabled']],
            'expanded' => false,
            'multiple' => false
        ]);

        $this->add('languages_choice_select_multiple', 'choice', [
            'choices' => ['en' => 'English', 'fr' => 'French', 'zh' => 'Chinese'],
            'choice_options' => [
                'wrapper' => ['class' => 'choice-wrapper'],
                'label_attr' => ['class' => 'label-class'],
            ],
            'selected' => ['en', 'fr'],
            'option_attributes' => ['zh' => ['disabled' => 'disabled']],
            'expanded' => false,
            'multiple' => true
        ]);

        $this->add('languages_checkbox', 'choice', [
            'choices' => ['en' => 'English', 'fr' => 'French', 'zh' => 'Chinese'],
            'choice_options' => [
                'wrapper' => ['class' => 'choice-wrapper'],
                'label_attr' => ['class' => 'label-class'],
            ],
            'option_attributes' => ['zh' => ['disabled' => 'disabled']],
            'selected' => ['en', 'fr'],
            'expanded' => true,
            'multiple' => true
        ]);

        $this->add('languages_radio', 'choice', [
            'choices' => ['en' => 'English', 'fr' => 'French', 'zh' => 'Chinese'],
            'choice_options' => [
                'wrapper' => ['class' => 'choice-wrapper'],
                'label_attr' => ['class' => 'label-class'],
            ],
            'option_attributes' => ['zh' => ['disabled' => 'disabled']],
            'selected' => ['en'],
            'expanded' => true,
            'multiple' => false
        ]);
    }
}

```