### PR TITLE
Allow use of the property option to resolve value

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     ],
     "require": {
         "php": ">=7.1",
-        "laravelcollective/html": "5.6.*|^6|^7",
-        "illuminate/database": "5.6.*@dev|^6|^7",
-        "illuminate/validation": "5.6.*@dev|^6|^7"
+        "laravelcollective/html": "^5.6|^6|^7",
+        "illuminate/database": "^5.6@dev|^6|^7",
+        "illuminate/validation": "^5.6@dev|^6|^7"
     },
     "require-dev": {
         "orchestra/testbench": "~3.6"

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -142,7 +142,8 @@ abstract class FormField
         }
 
         if (($value === null || $value instanceof \Closure) && !$isChild) {
-            $this->setValue($this->getModelValueAttribute($this->parent->getModel(), $this->name));
+            $attributeName = $this->getOption('property', $this->name);
+            $this->setValue($this->getModelValueAttribute($this->parent->getModel(), $attributeName));
         } elseif (!$isChild) {
             $this->hasDefault = true;
         }


### PR DESCRIPTION
**What has changed?**
Allows the model attribute name to be defined as option to resolve the value from the model, useful for when an accessor is used to modify the value on retrieval, but it should be stored in the database as the field name.


**Personal use case example**
```
//old method
$form->add('coverages', 'choice', [
    'selected' => $this->getModel()->form_coverages,
]);

//new method
$form->add('coverages', 'choice', [
    'property' => 'form_coverages',
]);
```

What did this fix for me?
Being able to use `setValue` on the form field afterwards. With hard defining the selected (default) value, the `setValue` method becomes unusable since it early returns if the field has a default value.