### PR TITLE
Allow use of the property option to resolve value

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -142,7 +142,8 @@ abstract class FormField
         }
 
         if (($value === null || $value instanceof \Closure) && !$isChild) {
-            $this->setValue($this->getModelValueAttribute($this->parent->getModel(), $this->name));
+            $attributeName = $this->getOption('property', $this->name);
+            $this->setValue($this->getModelValueAttribute($this->parent->getModel(), $attributeName));
         } elseif (!$isChild) {
             $this->hasDefault = true;
         }

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -11,6 +11,11 @@ use Kris\LaravelFormBuilder\Filters\FilterResolver;
 
 class TestModel extends Model {
     protected $fillable = ['m', 'f'];
+
+    public function getAccessorAttribute($value)
+    {
+        return 'accessor value';
+    }
 }
 
 abstract class FormBuilderTestCase extends TestCase {

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -716,11 +716,12 @@ class FormTest extends FormBuilderTestCase
     /** @test */
     public function it_can_add_child_form_as_field()
     {
-        $form = $this->formBuilder->plain();
+        $model = ['song' => ['body' => 'test body'], 'title' => 'main title'];
+        $form = $this->formBuilder->plain([
+            'model' => $model,
+        ]);
         $customForm = $this->formBuilder->create('CustomDummyForm');
         $customForm->add('img', 'file')->add('name', 'text', ['label_show' => false]);
-        $model = ['song' => ['body' => 'test body'], 'title' => 'main title'];
-        $form->setModel($model);
 
         $form
             ->add('title', 'text', [
@@ -780,6 +781,20 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_can_use_model_property_to_set_value()
+    {
+        $form = $this->formBuilder->plain([
+            'model' => $this->model,
+        ]);
+
+        $form->add('alias_accessor', 'choice', [
+            'property' => 'accessor',
+        ]);
+
+        $this->assertEquals($form->alias_accessor->getValue(), $this->model->accessor);
+    }
+
+    /** @test */
     public function it_reads_configuration_properly()
     {
         $config = $this->config;
@@ -820,10 +835,11 @@ class FormTest extends FormBuilderTestCase
     /** @test */
     public function it_removes_children_from_parent_type_fields()
     {
-        $form = $this->formBuilder->plain();
-        $customForm = $this->formBuilder->create('CustomDummyForm');
         $model = ['song' => ['title' => 'test song title', 'body' => 'test body'], 'title' => 'main title'];
-        $form->setModel($model);
+        $form = $this->formBuilder->plain([
+            'model' => $model,
+        ]);
+        $customForm = $this->formBuilder->create('CustomDummyForm');
 
         $form
             ->add('title', 'text')


### PR DESCRIPTION
**What has changed?**
Allows the model attribute name to be defined as option to resolve the value from the model, useful for when an accessor is used to modify the value on retrieval, but it should be stored in the database as the field name.


**Personal use case example**
```
//old method
$form->add('coverages', 'choice', [
    'selected' => $this->getModel()->form_coverages,
]);

//new method
$form->add('coverages', 'choice', [
    'property' => 'form_coverages',
]);
```

What did this fix for me?
Being able to use `setValue` on the form field afterwards. With hard defining the selected (default) value, the `setValue` method becomes unusable since it early returns if the field has a default value.

This is an update/cleanup from https://github.com/kristijanhusak/laravel-form-builder/pull/596 to include a test case and exclude the composer.json change from https://github.com/kristijanhusak/laravel-form-builder/pull/597