### PR TITLE
Fixes issue where the entity field was not set to the model value

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -142,7 +142,12 @@ abstract class FormField
         }
 
         if (($value === null || $value instanceof \Closure) && !$isChild) {
-            $attributeName = $this->getOption('property', $this->name);
+            if ($this instanceof EntityType) {
+                $attributeName = $this->name;
+            } else {
+                $attributeName = $this->getOption('property', $this->name);
+            }
+
             $this->setValue($this->getModelValueAttribute($this->parent->getModel(), $attributeName));
         } elseif (!$isChild) {
             $this->hasDefault = true;

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -795,6 +795,26 @@ class FormTest extends FormBuilderTestCase
     }
 
     /** @test */
+    public function it_sets_entity_field_value_to_the_entity_model_value()
+    {
+        $dummyModel = new DummyModel();
+        $dummyModel->id = 1;
+
+        $this->model->dummy_model_id = $dummyModel->id;
+
+        $form = $this->formBuilder
+            ->plain([
+                'model' => $this->model,
+            ])
+            ->add('dummy_model_id', 'entity', [
+                'class' => DummyModel::class,
+                'property' => 'name',
+            ]);
+
+        $this->assertEquals($form->dummy_model_id->getValue(), $this->model->dummy_model_id);
+    }
+
+    /** @test */
     public function it_reads_configuration_properly()
     {
         $config = $this->config;


### PR DESCRIPTION
We should not use the `property` option on an instance of the `EntityType` field, because it uses the `property` option to resolve the display name of the field. 

There was no unit test that validated that the value of the entity in the existing model was set as the value of the entity field.

This PR fixes the issue for the `EntityType` field and adds the unit test to validate this works.
