### PR TITLE
Fixes bug from #620 introduced in #598: general field option 'property' clashes with collection field

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false">
+    >
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -145,7 +145,7 @@ abstract class FormField
             if ($this instanceof EntityType) {
                 $attributeName = $this->name;
             } else {
-                $attributeName = $this->getOption('property', $this->name);
+                $attributeName = $this->getOption('value_property', $this->name);
             }
 
             $this->setValue($this->getModelValueAttribute($this->parent->getModel(), $attributeName));

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -139,6 +139,25 @@ namespace {
             }
         }
 
+        /** @test */
+        public function it_creates_collection_with_child_form_with_correct_model_properties()
+        {
+            $items = new \Illuminate\Support\Collection([
+                (new DummyEloquentModel2())->forceFill(['id' => 1, 'foo' => 'bar']),
+                (new DummyEloquentModel2())->forceFill(['id' => 2, 'foo' => 'baz']),
+            ]);
+
+            $model = (new DummyEloquentModel())->forceFill(['id' => 11]);
+            $model->setRelation('items', $items);
+
+            $form = $this->formBuilder->create('\LaravelFormBuilderCollectionTypeTest\Forms\NamespacedDummyFormCollectionForm', [
+                'model' => $model,
+            ]);
+
+            $collectionValue = $form->getField('items')->getOption('data');
+            $this->assertEquals($items, $collectionValue);
+        }
+
         /**
          * @test
          */
@@ -226,5 +245,26 @@ namespace LaravelFormBuilderCollectionTypeTest\Forms {
 
     class NamespacedDummyForm extends Form
     {
+    }
+
+    class NamespacedDummyFormCollectionChildForm extends Form
+    {
+        function buildForm()
+        {
+            $this->add('foo', 'text');
+        }
+    }
+
+    class NamespacedDummyFormCollectionForm extends Form
+    {
+        function buildForm()
+        {
+            $this->add('items', 'collection', [
+                'type' => 'form',
+                'options' => [
+                    'class' => NamespacedDummyFormCollectionChildForm::class,
+                ],
+            ]);
+        }
     }
 }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -468,7 +468,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->only('remember', 'name');
 
         $this->assertEquals(2, count($this->plainForm->getFields()));
-        
+
         $this->assertTrue($this->plainForm->has('remember'));
         $this->assertTrue($this->plainForm->has('name'));
         $this->assertFalse($this->plainForm->has('description'));
@@ -788,7 +788,7 @@ class FormTest extends FormBuilderTestCase
         ]);
 
         $form->add('alias_accessor', 'choice', [
-            'property' => 'accessor',
+            'value_property' => 'accessor',
         ]);
 
         $this->assertEquals($form->alias_accessor->getValue(), $this->model->accessor);


### PR DESCRIPTION
Bug introduced in #598 because the `property` option already exists in `collection` fields with default value `'id'`, so it **always** takes the `id` property for collection fields, which is always wrong.

Bug only noted in #620, because I suck, and automated tests didn't catch above bug.

Only fix IMO: rename the general `property` option to `value_property`, so it doesn't clash with the `collection` field option. Can't rename that one, because it's much older and officially released. Sorry @SanderMuller but that's a breaking change for you.

Added a CollectionType test to make sure the correct value is used.

I need a professional opinion here @kristijanhusak because I screwed this up before.

I will update the docs for `value_property` after merge.