### PR TITLE
Use collection empty_model option for keeping model data intact during validation (errors)

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -104,14 +104,14 @@ class CollectionType extends ParentType
             $data = $currentInput;
         }
 
+        if ($data instanceof Collection) {
+            $data = $data->all();
+        }
+
         // Needs to have more than 1 item because 1 is rendered by default.
         // This overrides current request in situations when validation fails.
         if ($oldInput && count($oldInput) > 1) {
             $data = $this->formatInputIntoModels($oldInput, $data);
-        }
-
-        if ($data instanceof Collection) {
-            $data = $data->all();
         }
 
         $field = new $fieldType($this->name, $type, $this->parent, $this->getOption('options'));

--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -40,6 +40,7 @@ class CollectionType extends ParentType
             'prototype_name' => '__NAME__',
             'empty_row' => true,
             'prefer_input' => false,
+            'empty_model' => null,
         ];
     }
 
@@ -106,7 +107,7 @@ class CollectionType extends ParentType
         // Needs to have more than 1 item because 1 is rendered by default.
         // This overrides current request in situations when validation fails.
         if ($oldInput && count($oldInput) > 1) {
-            $data = $oldInput;
+            $data = $this->formatInputIntoModels($oldInput, $data);
         }
 
         if ($data instanceof Collection) {
@@ -120,9 +121,8 @@ class CollectionType extends ParentType
         }
 
         if (!$data || empty($data)) {
-            if ($empty = $this->getOption('empty_row')) {
-                $val = $empty === true ? null : $empty;
-                return $this->children[] = $this->setupChild(clone $field, '[0]', $val);
+            if ($this->getOption('empty_row')) {
+                return $this->children[] = $this->setupChild(clone $field, '[0]', $this->makeEmptyRowValue());
             }
 
             return $this->children = [];
@@ -137,6 +137,36 @@ class CollectionType extends ParentType
         foreach ($data as $key => $val) {
             $this->children[] = $this->setupChild(clone $field, '['.$key.']', $val);
         }
+    }
+
+    protected function makeEmptyRowValue()
+    {
+        $empty = $this->getOption('empty_row');
+        return $empty === true ? $this->makeNewEmptyModel() : $empty;
+    }
+
+    protected function makeNewEmptyModel()
+    {
+        return value($this->getOption('empty_model'));
+    }
+
+    protected function formatInputIntoModels(array $input, array $originalData = [])
+    {
+        if (!$this->getOption('empty_model')) {
+            return $input;
+        }
+
+        $newData = [];
+        foreach ($input as $k => $inputItem) {
+            if (is_array($inputItem)) {
+                $newData[$k] = tap($originalData[$k] ?? $this->makeNewEmptyModel())->forceFill($inputItem);
+            }
+            else {
+                $newData[$k] = $inputItem;
+            }
+        }
+
+        return $newData;
     }
 
     /**
@@ -180,7 +210,7 @@ class CollectionType extends ParentType
      */
     protected function generatePrototype(FormField $field)
     {
-        $value = $field instanceof ChildFormType ? false : null;
+        $value = $this->makeNewEmptyModel();
         $field->setOption('is_prototype', true);
         $field = $this->setupChild($field, $this->getPrototypeName(), $value);
 

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -228,6 +228,74 @@ namespace {
                 $form->dummy_collection->prototype()->title->getValue()
             );
         }
+
+        /** @test */
+        public function it_uses_empty_model_for_empty_row_child_form()
+        {
+            $items = new \Illuminate\Support\Collection([]);
+
+            $model = (new DummyEloquentModel())->forceFill(['id' => 11]);
+            $model->setRelation('items', $items);
+
+            $form = $this->formBuilder->create('\LaravelFormBuilderCollectionTypeTest\Forms\NamespacedDummyFormCollectionForm', [
+                'model' => $model,
+            ]);
+
+            $itemsChildren = $form->getField('items')->getChildren();
+            $this->assertEquals(1, count($itemsChildren));
+            $this->assertInstanceOf(DummyEloquentModel2::class, $itemsChildren[0]->getForm()->getModel());
+        }
+
+        /** @test */
+        public function it_uses_empty_model_for_proto_child_forms()
+        {
+            $items = new \Illuminate\Support\Collection([
+                (new DummyEloquentModel2())->forceFill(['id' => 21, 'foo' => 'bar 21']),
+            ]);
+
+            $model = (new DummyEloquentModel())->forceFill(['id' => 21]);
+            $model->setRelation('items', $items);
+
+            $form = $this->formBuilder->create('\LaravelFormBuilderCollectionTypeTest\Forms\NamespacedDummyFormCollectionForm', [
+                'model' => $model,
+            ]);
+
+            $protoField = $form->getField('items')->prototype();
+            $protoModel = $protoField->getForm()->getModel();
+            $this->assertInstanceOf(DummyEloquentModel2::class, $protoModel);
+            $this->assertTrue($protoModel->_custom);
+        }
+
+        /** @test */
+        public function it_uses_empty_model_for_new_collection_children_after_validation_error()
+        {
+            $items = new \Illuminate\Support\Collection([
+                (new DummyEloquentModel2())->forceFill(['id' => 31, 'foo' => 'bar31']),
+            ]);
+
+            $model = (new DummyEloquentModel())->forceFill(['id' => 31]);
+            $model->setRelation('items', $items);
+
+            $this->session([
+                '_old_input' => ['items' => [
+                    ['foo' => 'bar21 B'],
+                    ['foo' => 'bar22 NEW']
+                ]],
+            ]);
+
+            $form = $this->formBuilder->create('\LaravelFormBuilderCollectionTypeTest\Forms\NamespacedDummyFormCollectionForm', [
+                'model' => $model,
+            ]);
+
+            $itemsChildren = $form->getField('items')->getChildren();
+            $this->assertEquals(2, count($itemsChildren));
+
+            foreach ($itemsChildren as $childField) {
+                $childFormModel = $childField->getForm()->getModel();
+                $this->assertInstanceOf(DummyEloquentModel2::class, $childFormModel);
+            }
+        }
+
     }
 
     class DummyEloquentModel extends Model {
@@ -242,6 +310,7 @@ namespace {
 namespace LaravelFormBuilderCollectionTypeTest\Forms {
 
     use Kris\LaravelFormBuilder\Form;
+    use DummyEloquentModel2;
 
     class NamespacedDummyForm extends Form
     {
@@ -261,6 +330,11 @@ namespace LaravelFormBuilderCollectionTypeTest\Forms {
         {
             $this->add('items', 'collection', [
                 'type' => 'form',
+                'prefer_input' => true,
+                'empty_row' => true,
+                'empty_model' => function() {
+                    return (new DummyEloquentModel2())->forceFill(['_custom' => true]);
+                },
                 'options' => [
                     'class' => NamespacedDummyFormCollectionChildForm::class,
                 ],


### PR DESCRIPTION
This is the better version of #519, with the same intent:

- Keep model input as models during validation errors, so child forms always have a predictable model object as `$this->model`, instead of an array.
- Make all not-model collection rows from a predictable real model (like prototype and empty row), which currently get the parent model as the child model, which is just weirdd.

Usage:

```
class SiteCostsForm extends Form {
	public function buildForm() {
		$this->add('costs', 'collection', [
			'type' => 'form',
			'prototype' => true,
			'prefer_input' => true,

			'empty_model' => fn() => new SiteCost(), // <<<

			'options' => [
				'class' => SiteCostForm::class,
			],
		]);
	}
}
```

`empty_model` will be run for every row that doesn't have a model:

- empty_row
- prototype
- **new** rows from form input (`$oldInput`) during validation

Existing rows during validation will get their original model object. That's new too. `formatInputIntoModels()` combines form input and db data.

@kristijanhusak I'm pretty sure about this one, except for one thing: `generatePrototype()`. It used to distinguish between `null` and `false`, but I can't find any different anywhere. Both `null` and `false` would use the parent model in the child form. With this change it uses `empty_model` or null (the parent model).