### PR TITLE
Use modern versions of PHP and Laravel for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 12
       matrix:
-        php: ['7.1', '7.2', '7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
         package-release: [source, dist]
     steps:
       - name: Checkout repository
@@ -40,10 +40,6 @@ jobs:
             composer-${{ runner.os }}-${{ matrix.php }}-${{ matrix.package-release }}-
             composer-${{ runner.os }}-${{ matrix.php }}-
             composer-${{ runner.os }}-
-
-      - name: Pretend to be PHP 7.4
-        if: matrix.php == '8.0'
-        run: composer config platform.php 7.4.2
 
       - name: Install composer dependencies
         run: composer install --no-suggest --no-progress --no-interaction --prefer-${{ matrix.package-release }}

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,6 @@
         {
             "name": "Kristijan Husak",
             "email": "husakkristijan@gmail.com"
-        },
-        {
-            "name": "Mike Erickson",
-            "email": "codedungeon@gmail.com"
-        },
-        {
-            "name": "Mike Erickson",
-            "email": "mike.erickson@codedungeon.io"
         }
     ],
     "require": {
@@ -24,7 +16,7 @@
         "illuminate/validation": "^5.6@dev|^6|^7|^8"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.6"
+        "orchestra/testbench": "^6.13"
     },
     "extra": {
         "branch-alias": {

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -196,7 +196,8 @@ namespace {
          */
         public function it_throws_exception_when_data_is_not_iterable()
         {
-            $this->expectException(\Exception::class);
+            $this->expectException(\Throwable::class);
+            $this->expectExceptionMessageMatches('#count\(#');
 
             $options = [
                 'type' => 'text',

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -61,7 +61,7 @@ class FormFieldTest extends FormBuilderTestCase
         $hidden = new InputType('hidden_id', 'hidden', $this->plainForm, $options);
         $hidden->render();
 
-        $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
+        $this->assertMatchesRegularExpression('/required/', $hidden->getOption('label_attr.class'));
         $this->assertArrayHasKey('required', $hidden->getOption('attr'));
     }
 
@@ -75,7 +75,7 @@ class FormFieldTest extends FormBuilderTestCase
         $hidden = new InputType('hidden_id', 'hidden', $this->plainForm, $options);
         $hidden->render();
 
-        $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
+        $this->assertMatchesRegularExpression('/required/', $hidden->getOption('label_attr.class'));
         $this->assertArrayHasKey('required', $hidden->getOption('attr'));
     }
 
@@ -91,7 +91,7 @@ class FormFieldTest extends FormBuilderTestCase
         $hidden = new InputType('hidden_id', 'hidden', $this->plainForm, $options);
         $hidden->render();
 
-        $this->assertRegExp('/required/', $hidden->getOption('label_attr.class'));
+        $this->assertMatchesRegularExpression('/required/', $hidden->getOption('label_attr.class'));
         $this->assertArrayNotHasKey('required', $hidden->getOption('attr'));
     }
 
@@ -107,11 +107,11 @@ class FormFieldTest extends FormBuilderTestCase
         $text = new InputType('field_name', 'text', $this->plainForm, $options);
         $renderResult = $text->render();
 
-        $this->assertRegExp('/appended/', $text->getOption('attr.class'));
+        $this->assertMatchesRegularExpression('/appended/', $text->getOption('attr.class'));
 
         $defaultClasses = $this->config['defaults']['field_class'];
         $this->assertEquals('form-control appended', $text->getOption('attr.class'));
-        
+
         $this->assertStringContainsString($defaultClasses, $text->getOption('attr.class'));
         $this->assertStringNotContainsString('class_append', $renderResult);
     }
@@ -128,11 +128,11 @@ class FormFieldTest extends FormBuilderTestCase
         $text = new InputType('field_name', 'text', $this->plainForm, $options);
         $renderResult = $text->render();
 
-        $this->assertRegExp('/appended/', $text->getOption('label_attr.class'));
+        $this->assertMatchesRegularExpression('/appended/', $text->getOption('label_attr.class'));
 
         $defaultClasses = $this->config['defaults']['label_class'];
         $this->assertEquals('control-label appended', $text->getOption('label_attr.class'));
-        
+
         $this->assertStringContainsString($defaultClasses, $text->getOption('label_attr.class'));
         $this->assertStringNotContainsString('class_append', $renderResult);
     }
@@ -149,11 +149,11 @@ class FormFieldTest extends FormBuilderTestCase
         $text = new InputType('field_name', 'text', $this->plainForm, $options);
         $renderResult = $text->render();
 
-        $this->assertRegExp('/appended/', $text->getOption('wrapper.class'));
+        $this->assertMatchesRegularExpression('/appended/', $text->getOption('wrapper.class'));
 
         $defaultClasses = $this->config['defaults']['wrapper_class'];
         $this->assertEquals('form-group appended', $text->getOption('wrapper.class'));
-        
+
         $this->assertStringContainsString($defaultClasses, $text->getOption('wrapper.class'));
         $this->assertStringNotContainsString('class_append', $renderResult);
     }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -91,7 +91,7 @@ class FormTest extends FormBuilderTestCase
 
         $errors = [
             'name' => ['The Name field is required.'],
-            'description' => ['The Description may not be greater than 10 characters.']
+            'description' => ['The Description must not be greater than 10 characters.']
         ];
 
         $this->assertEquals($errors, $this->plainForm->getErrors());
@@ -153,7 +153,7 @@ class FormTest extends FormBuilderTestCase
             $errorBag = $response->getSession()->get('errors');
             $this->assertTrue($errorBag->has('description'));
             $this->assertTrue($errorBag->has('name'));
-            $this->assertEquals('The Description may not be greater than 10 characters.', $errorBag->first('description'));
+            $this->assertEquals('The Description must not be greater than 10 characters.', $errorBag->first('description'));
         }
     }
 
@@ -191,7 +191,7 @@ class FormTest extends FormBuilderTestCase
             $errorBag = $response->getSession()->get('errors');
             $this->assertTrue($errorBag->has('description'));
             $this->assertTrue($errorBag->has('name'));
-            $this->assertEquals('The Description may not be greater than 10 characters.', $errorBag->first('description'));
+            $this->assertEquals('The Description must not be greater than 10 characters.', $errorBag->first('description'));
         }
     }
 
@@ -233,7 +233,7 @@ class FormTest extends FormBuilderTestCase
 
         $errors = [
             'name' => ['Name field must be numeric.'],
-            'description' => ['The Description may not be greater than 10 characters.'],
+            'description' => ['The Description must not be greater than 10 characters.'],
             'age' => ['The age field is a must.'],
             'email' => ['The email is very required.']
         ];
@@ -766,9 +766,9 @@ class FormTest extends FormBuilderTestCase
             $form->song->getForm()
         );
 
-        $this->assertNotRegExp('/label.*for="name"/', $view);
-        $this->assertRegExp('/label.*for="custom_title"/', $view);
-        $this->assertRegExp('/input.*id="custom_title"/', $view);
+        $this->assertDoesNotMatchRegularExpression('/label.*for="name"/', $view);
+        $this->assertMatchesRegularExpression('/label.*for="custom_title"/', $view);
+        $this->assertMatchesRegularExpression('/input.*id="custom_title"/', $view);
 
         $this->assertTrue($form->song->getFormOption('files'));
 
@@ -833,11 +833,11 @@ class FormTest extends FormBuilderTestCase
         $formView = $form->renderForm();
         $overridenView = $overridenClassForm->renderForm();
 
-        $this->assertRegExp('/textarea.*class="my-textarea-class"/', $formView);
-        $this->assertRegExp('/input.*class="form-control"/', $formView);
+        $this->assertMatchesRegularExpression('/textarea.*class="my-textarea-class"/', $formView);
+        $this->assertMatchesRegularExpression('/input.*class="form-control"/', $formView);
 
-        $this->assertRegExp('/textarea.*class="overwrite-textarea-class"/', $overridenView);
-        $this->assertRegExp('/input.*class="my-text-class"/', $overridenView);
+        $this->assertMatchesRegularExpression('/textarea.*class="overwrite-textarea-class"/', $overridenView);
+        $this->assertMatchesRegularExpression('/input.*class="my-text-class"/', $overridenView);
     }
 
     /** @test */


### PR DESCRIPTION
PHP 7.1 and 7.2 aren't relevant anymore.

dev-requiring `orchestra/testbench` version `~3.6` capped Laravel test version at 6.x, which is pretty old now.