### PR TITLE
improves collection formatInputIntoModels() during postback

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -101,7 +101,7 @@ class CollectionType extends ParentType
         }
         // Or if the current request input is preferred over original data.
         elseif ($this->getOption('prefer_input') && count($currentInput)) {
-            $data = $currentInput;
+            $data = $this->formatInputIntoModels($currentInput, $data);
         }
 
         if ($data instanceof Collection) {


### PR DESCRIPTION
I can't believe I missed this. During POST, when the form is being built, if the collection has `prefer_input` enabled, the raw POST data is used as collection data, instead of the configured data. If `empty_model` is enabled, that raw POST data should be formatted into models too. Not just after validation errors, when the form is being rebuilt for input, but also during POST, when the form is being rebuilt for validation.