### PR TITLE
+default field alter for checkbox fields

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CheckableType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CheckableType.php
@@ -5,6 +5,8 @@ namespace  Kris\LaravelFormBuilder\Fields;
 class CheckableType extends FormField
 {
 
+    const DEFAULT_VALUE = 1;
+
     /**
      * @inheritdoc
      */
@@ -25,7 +27,7 @@ class CheckableType extends FormField
     {
         return [
             'attr' => ['class' => null, 'id' => $this->getName()],
-            'value' => 1,
+            'value' => self::DEFAULT_VALUE,
             'checked' => null
         ];
     }


### PR DESCRIPTION
An unchecked checkbox will post nothing, so `getFieldValues(true)` will return null, and `getFieldValues(false)` won't return the key at all. But an unchecked field submitted, is a submitted value.

`getFieldValues()` should always return true/false or 1/0 for bool fields. Except if the dev changed the checkbox `value` to something else, in which case it might not be a 'real' boolean field anymore.