### PR TITLE
choice checkboxes required attributes bugfix

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ChoiceType.php
@@ -4,6 +4,8 @@ namespace  Kris\LaravelFormBuilder\Fields;
 
 class ChoiceType extends ParentType
 {
+    const DONT_COPY_OPTIONS_TO_CHECKBOXES = ['attr.required'];
+
     /**
      * @var string
      */
@@ -20,6 +22,32 @@ class ChoiceType extends ParentType
     protected function getTemplate()
     {
         return 'choice';
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function setChildrenOption($name, $value)
+    {
+        $checkboxes = $this->options['expanded'] && $this->options['multiple'];
+        if (!$checkboxes || !in_array($name, self::DONT_COPY_OPTIONS_TO_CHECKBOXES)) {
+            parent::setChildrenOption($name, $value);
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function setChildrenOptions($options)
+    {
+        $checkboxes = $this->options['expanded'] && $this->options['multiple'];
+        if ($checkboxes) {
+            $options = array_diff_key($options, array_flip(self::DONT_COPY_OPTIONS_TO_CHECKBOXES));
+        }
+
+        foreach ((array) $this->children as $key => $child) {
+            $this->children[$key]->setOptions($options);
+        }
     }
 
     /**
@@ -72,7 +100,7 @@ class ChoiceType extends ParentType
         if (($data_override = $this->getOption('data_override')) && $data_override instanceof \Closure) {
             $this->options['choices'] = $data_override($this->options['choices'], $this);
         }
-        
+
         $this->children = [];
         $this->determineChoiceField();
 

--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -102,12 +102,18 @@ abstract class ParentType extends FormField
         parent::setOption($name, $value);
 
         if ($this->options['copy_options_to_children']) {
-            foreach ((array) $this->children as $key => $child) {
-                $this->children[$key]->setOption($name, $value);
-            }
+            $this->setChildrenOption($name, $value);
         }
+    }
 
-        return $this;
+    /**
+     * Set an option in all children
+     */
+    protected function setChildrenOption($name, $value)
+    {
+        foreach ((array) $this->children as $key => $child) {
+            $this->children[$key]->setOption($name, $value);
+        }
     }
 
     /**
@@ -118,12 +124,20 @@ abstract class ParentType extends FormField
         parent::setOptions($options);
 
         if ($this->options['copy_options_to_children']) {
-            foreach ((array) $this->children as $key => $child) {
-                $this->children[$key]->setOptions($options);
-            }
+            $this->setChildrenOptions($options);
         }
 
         return $this;
+    }
+
+    /**
+     * Set options in all children
+     */
+    protected function setChildrenOptions($options)
+    {
+        foreach ((array) $this->children as $key => $child) {
+            $this->children[$key]->setOptions($options);
+        }
     }
 
     /**


### PR DESCRIPTION
Never copy the `required` attr to a ChoiceType's children if they're checkboxes. For select or radiobuttons it's okay, but not for checkboxes, because that makes every individual checkbox required.