### PR TITLE
array_filter function removed

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -1403,8 +1403,8 @@ class Form
     {
         // If filtering is unlocked/allowed we can start with filtering process.
         if (!$this->isFilteringLocked()) {
-            $filters = array_filter($this->getFilters());
-
+            //$filters = array_filter($this->getFilters());
+            $filters = $this->getFilters();
             if (count($filters)) {
                 $dotForm = $this->getNameKey();
 


### PR DESCRIPTION
array_filter function removed because, If no callback is supplied, all empty entries of array will be removed.