### PR TITLE
Allow Escape HTML via customLabel()

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -84,13 +84,13 @@ class FormBuilderServiceProvider extends ServiceProvider
 
         $form = $this->app['form'];
 
-        $form->macro('customLabel', function($name, $value, $options = []) use ($form) {
+        $form->macro('customLabel', function($name, $value, $options = [], $escape_html = true) use ($form) {
             if (isset($options['for']) && $for = $options['for']) {
                 unset($options['for']);
-                return $form->label($for, $value, $options);
+                return $form->label($for, $value, $options, $escape_html);
             }
 
-            return $form->label($name, $value, $options);
+            return $form->label($name, $value, $options, $escape_html);
         });
     }
 


### PR DESCRIPTION
Allow clients to turn off escaping for labels with `Form::customLabel()`.