### PR TITLE
Change mergeOptions() to merge instead of replacing by key.

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -137,7 +137,7 @@ class FormHelper
      */
     public function mergeOptions(array $targetOptions, array $sourceOptions)
     {
-        return array_replace_recursive($targetOptions, $sourceOptions);
+        return array_merge_recursive($targetOptions, $sourceOptions);
     }
 
 


### PR DESCRIPTION
In my use case, we've extended FormBuilder\Fields\SelectType and we're supplying values for $options['rules'] and $options['rules_append'] in in getDefaults( ) and the consructor respectively, but these are being removed if there are values set in $form->add(... 'rules' => [...]).

This is because on FormField line 273, we use this helper to merge options from the class and those from $form->add(...). array_replace_recursive(), however, replaces based on key value. And key value is just basic integers. Instead, we need to array_merge_recursive().