### PR TITLE
Added `setRendered` method to `FormField` class.

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -517,6 +517,18 @@ abstract class FormField
     }
 
     /**
+     * Marks the view as rendered.
+     *
+     * @return $this
+     */
+    public function setRendered()
+    {
+        $this->rendered = true;
+
+        return $this;
+    }
+
+    /**
      * Default options for field.
      *
      * @return array


### PR DESCRIPTION
We need the function of marking the view as rendered that is like Symfony.

https://github.com/symfony/symfony/blob/e7142a6651bedb33dcce7fb33d2895e3032764e4/src/Symfony/Component/Form/FormView.php#L83