### PR TITLE
Customizable classes by config.

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -35,10 +35,10 @@ class FormBuilderServiceProvider extends ServiceProvider
 
         $this->app->singleton('laravel-form-builder', function ($app) {
 
-            return new FormBuilder($app, $app['laravel-form-helper'], $app['events']);
+            return new config('laravel-form-builder.form_builder', FormBuilder::class)($app, $app['laravel-form-helper'], $app['events']);
         });
 
-        $this->app->alias('laravel-form-builder', 'Kris\LaravelFormBuilder\FormBuilder');
+        $this->app->alias('laravel-form-builder', config('laravel-form-builder.form_builder', FormBuilder::class));
 
         $this->app->afterResolving(Form::class, function ($object, $app) {
             $request = $app->make('request');
@@ -62,10 +62,10 @@ class FormBuilderServiceProvider extends ServiceProvider
 
             $configuration = $app['config']->get('laravel-form-builder');
 
-            return new FormHelper($app['view'], $app['translator'], $configuration);
+            return new config('laravel-form-builder.form_builder', FormHelper::class)($app['view'], $app['translator'], $configuration);
         });
 
-        $this->app->alias('laravel-form-helper', 'Kris\LaravelFormBuilder\FormHelper');
+        $this->app->alias('laravel-form-helper', config('laravel-form-builder.form_builder', FormHelper::class));
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -48,5 +48,8 @@ return [
 
     'custom_fields' => [
 //        'datetime' => App\Forms\Fields\Datetime::class
-    ]
+    ],
+
+    'form_builder' => \Kris\LaravelFormBuilder\FormBuilder::class,
+    'helper' => \Kris\LaravelFormBuilder\FormHelper::class,
 ];

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -50,6 +50,7 @@ return [
 //        'datetime' => App\Forms\Fields\Datetime::class
     ],
 
-    'form_builder' => \Kris\LaravelFormBuilder\FormBuilder::class,
-    'helper' => \Kris\LaravelFormBuilder\FormHelper::class,
+    'plain_form_class' => \Kris\LaravelFormBuilder\Form::class,
+    'form_builder_class' => \Kris\LaravelFormBuilder\FormBuilder::class,
+    'form_helper_class' => \Kris\LaravelFormBuilder\FormHelper::class,
 ];

--- a/tests/FormBuilderServiceProviderTest.php
+++ b/tests/FormBuilderServiceProviderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Collective\Html\FormBuilder as LaravelForm;
+use Collective\Html\HtmlBuilder;
+use Kris\LaravelFormBuilder\FormBuilder;
+use Kris\LaravelFormBuilder\FormBuilderServiceProvider;
+use Kris\LaravelFormBuilder\FormHelper;
+
+class FormBuilderServiceProviderTest extends FormBuilderTestCase
+{
+    /** @test */
+    public function it_provides(): void
+    {
+        $provider = new FormBuilderServiceProvider($this->app);
+
+        $this->assertEquals(
+            [
+                'laravel-form-builder',
+            ],
+            $provider->provides()
+        );
+    }
+
+    /** @test */
+    public function it_register(): void
+    {
+        $provider = new FormBuilderServiceProvider($this->app);
+
+        $provider->register();
+
+        $this->assertTrue($this->app->bound('html'));
+        $this->assertInstanceOf(HtmlBuilder::class, $this->app['html']);
+
+        $this->assertTrue($this->app->bound('form'));
+        $this->assertInstanceOf(LaravelForm::class, $this->app['form']);
+
+        $this->assertTrue($this->app->bound('laravel-form-builder'));
+        $this->assertInstanceOf(FormBuilder::class, $this->app['laravel-form-builder']);
+
+        $this->assertTrue($this->app->bound('laravel-form-helper'));
+        $this->assertInstanceOf(FormHelper::class, $this->app['laravel-form-helper']);
+    }
+}

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -2,12 +2,13 @@
 
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Factory;
-use Kris\LaravelFormBuilder\FormBuilder;
-use Kris\LaravelFormBuilder\FormHelper;
-use Kris\LaravelFormBuilder\Form;
-use Orchestra\Testbench\TestCase;
 use Illuminate\Database\Eloquent\Model;
 use Kris\LaravelFormBuilder\Filters\FilterResolver;
+use Kris\LaravelFormBuilder\Form;
+use Kris\LaravelFormBuilder\FormBuilder;
+use Kris\LaravelFormBuilder\FormHelper;
+use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Constraint\IsIdentical;
 
 class TestModel extends Model {
     protected $fillable = ['m', 'f'];
@@ -151,5 +152,10 @@ abstract class FormBuilderTestCase extends TestCase {
     protected function assertNotThrown(): void
     {
         $this->assertTrue(true);
+    }
+
+    protected function assertIdentical($one, $two): void
+    {
+        self::assertThat($one, new IsIdentical($two));
     }
 }


### PR DESCRIPTION
Customizable classes by config.

e.g.

```php
'form_builder' => \Kris\LaravelFormBuilder\FormBuilder::class,
'helper' => \App\Form\MyFormHelper::class,
```

```php
class MyFormHelper extend FormHelper
{
    public function mergeOptions(array $targetOptions, array $sourceOptions)
    {
        return $targetOptions + $sourceOptions;
    }
}
```