### PR TITLE
Allow Laravel ^9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=7.1",
-        "laravelcollective/html": "^5.6|^6|^7|^8",
-        "illuminate/database": "^5.6@dev|^6|^7|^8",
-        "illuminate/validation": "^5.6@dev|^6|^7|^8"
+        "laravelcollective/html": "^5.6|^6|^7|^8|^9",
+        "illuminate/database": "^5.6@dev|^6|^7|^8|^9",
+        "illuminate/validation": "^5.6@dev|^6|^7|^8|^9"
     },
     "require-dev": {
         "orchestra/testbench": "^6.13"


### PR DESCRIPTION
This should allow this package to be used with Laravel 9. Did a quick test and everything seems to work :) Please note that Laravel 9 requires PHP8+

I wasn't able to get the unittests fully running, so if someone is able to verify them that would be great!

Also fixes issue https://github.com/kristijanhusak/laravel-form-builder/issues/667