### PR TITLE
Added `isPlain()` method for modified plain form

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -187,7 +187,11 @@ class Form
      */
     protected function isPlain()
     {
-        return static::class === self::class;
+        if($this->formBuilder === null) {
+            throw new \RuntimeException('FormBuilder is not set');
+        }
+
+        return static::class === $this->formBuilder->getFormClass();
     }
 
     /**

--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -168,7 +168,7 @@ class Form
         $this->rebuilding = true;
         // If form is plain, buildForm method is empty, so we need to take
         // existing fields and add them again
-        if (get_class($this) === 'Kris\LaravelFormBuilder\Form') {
+        if ($this->isPlain()) {
             foreach ($this->fields as $name => $field) {
                 // Remove any temp variables added in previous instance
                 $options =  Arr::except($field->getOptions(), 'tmp');
@@ -180,6 +180,14 @@ class Form
         $this->rebuilding = false;
 
         return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    protected function isPlain()
+    {
+        return static::class === self::class;
     }
 
     /**

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -377,7 +377,7 @@ class FormFieldTest extends FormBuilderTestCase
         $methodName = 'isPlain';
 
         $plainForm = $this->formBuilder->plain();
-        $modifiedForm = new TestForm();
+        $modifiedForm = $this->formBuilder->create(TestForm::class);
 
         $reflection = new \ReflectionClass($plainForm);
         $method = $reflection->getMethod($methodName);
@@ -385,6 +385,23 @@ class FormFieldTest extends FormBuilderTestCase
 
         $this->assertTrue($method->invokeArgs($plainForm, []));
         $this->assertFalse($method->invokeArgs($modifiedForm, []));
+    }
+
+    /** @test */
+    public function it_custom_plain_form_is_plain()
+    {
+        $methodName = 'isPlain';
+
+        $this->formBuilder->setFormClass(TestForm::class);
+
+        $customPlainForm = $this->formBuilder->create(TestForm::class);
+
+        $reflection = new \ReflectionClass($customPlainForm);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+
+        $this->assertTrue($method->invokeArgs($customPlainForm, []));
     }
 }
 

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -370,6 +370,22 @@ class FormFieldTest extends FormBuilderTestCase
         $testField->clearFilters();
         $this->assertEmpty($testField->getFilters());
     }
+
+    /** @test */
+    public function it_is_plain()
+    {
+        $methodName = 'isPlain';
+
+        $plainForm = $this->formBuilder->plain();
+        $modifiedForm = new TestForm();
+
+        $reflection = new \ReflectionClass($plainForm);
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invokeArgs($plainForm, []));
+        $this->assertFalse($method->invokeArgs($modifiedForm, []));
+    }
 }
 
 


### PR DESCRIPTION

Added `isPlain()` method for modified plain form.

```php
use Kris\LaravelFormBuilder\Form;

class ModifiedPlainForm extends Form
{
    protected function isPlain()
    {
        return static::class === self::class;
    }
}
```

```php
$formBuilder->setFormClass(ModifiedPlainForm::class);
```