### PR TITLE
Smarter formatInputIntoModels for non-Models

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -2,6 +2,7 @@
 
 namespace Kris\LaravelFormBuilder\Fields;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
 class CollectionType extends ParentType
@@ -167,7 +168,7 @@ class CollectionType extends ParentType
         $newData = [];
         foreach ($input as $k => $inputItem) {
             if (is_array($inputItem)) {
-                $newData[$k] = tap($originalData[$k] ?? $this->makeNewEmptyModel())->forceFill($inputItem);
+                $newData[$k] = $this->formatInputIntoModel($originalData[$k] ?? $this->makeNewEmptyModel(), $inputItem);
             }
             else {
                 $newData[$k] = $inputItem;
@@ -175,6 +176,26 @@ class CollectionType extends ParentType
         }
 
         return $newData;
+    }
+
+    protected function formatInputIntoModel($model, $input)
+    {
+      if ($model instanceof Model) {
+        $model->forceFill($input);
+      }
+      elseif (is_object($model)) {
+        foreach ($input as $key => $value) {
+          $model->$key = $value;
+        }
+      }
+      elseif (is_array($model)) {
+        $model = $input + $model;
+      }
+      else {
+        $model = $input;
+      }
+
+      return $model;
     }
 
     /**


### PR DESCRIPTION
`empty_model` only works for Eloquent models, but it's also useful for an array of data. In GET that's used for the `prototype` and `empty_row` children. In POST it's used as a basis to put POST data into. Without `empty_model`, the parent model is used, which is weird. (That hasn't changed.) So it's always nice to have an `empty_model`, even if it's not a real `Model`.