### PR TITLE
Fix deprecation message if str_replace receive a null value in FormHelper

### DIFF
--- a/src/Kris/LaravelFormBuilder/Form.php
+++ b/src/Kris/LaravelFormBuilder/Form.php
@@ -644,6 +644,10 @@ class Form
      **/
     public function getNameKey()
     {
+        if ($this->name === null) {
+            return '';
+        }
+
         return $this->formHelper->transformToDotSyntax($this->name);
     }
 

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -456,7 +456,7 @@ class FormHelper
      */
     public function transformToDotSyntax($string)
     {
-        if (!$string) {
+        if ($string === null) {
             return '';
         }
 

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -456,6 +456,10 @@ class FormHelper
      */
     public function transformToDotSyntax($string)
     {
+        if (!$string) {
+            return '';
+        }
+
         return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $string);
     }
 

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -456,11 +456,7 @@ class FormHelper
      */
     public function transformToDotSyntax($string)
     {
-        if ($string === null) {
-            return '';
-        }
-
-        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $string);
+        return str_replace(['.', '[]', '[', ']'], ['_', '', '.', ''], $string ?? '');
     }
 
     /**

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -65,7 +65,7 @@ class CustomDummyForm extends Form
 
     public function alterFieldValues(array &$values)
     {
-        $values['body'] = strtoupper($values['body']);
+        $values['body'] = strtoupper($values['body'] ?? '');
     }
 
     public function alterValid(Form $mainForm, &$isValid)


### PR DESCRIPTION
> str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated


Today str_replace is returning a blank string if a null value is specified as subject