### PR TITLE
CollectionType alterFieldValues() items indexes/keys bugfix

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -79,10 +79,13 @@ class CollectionType extends ParentType
      */
     public function alterFieldValues(array &$values)
     {
-        foreach ($this->children as $i => $child) {
+        $stripLeft = strlen($this->getName()) + 1;
+        $stripRight = 1;
+        foreach ($this->children as $child) {
             if (method_exists($child, 'alterFieldValues')) {
-                if (isset($values[$i])) {
-                    $child->alterFieldValues($values[$i]);
+                $itemKey = substr($child->getName(), $stripLeft, -$stripRight);
+                if (isset($values[$itemKey])) {
+                    $child->alterFieldValues($values[$itemKey]);
                 }
             }
         }

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -352,8 +352,8 @@ class FormTest extends FormBuilderTestCase
         $this->request['name'] = 'lower case';
         $this->request['subcustom'] = ['title' => 'Bar foo', 'body' => 'Foo bar'];
         $this->request['subcustom_collection'] = [
-            ['title' => 'Item 1 title', 'body' => 'Item 1 body'],
-            ['title' => 'Item 2 title', 'body' => 'Item 2 body'],
+            5 => ['title' => 'Item 1 title', 'body' => 'Item 1 body'],
+            17 => ['title' => 'Item 2 title', 'body' => 'Item 2 body'],
         ];
 
         $customForm = $this->formBuilder->create('CustomNesterDummyForm');
@@ -364,8 +364,8 @@ class FormTest extends FormBuilderTestCase
                 'options' => ['x'],
                 'subcustom' => ['title' => 'Bar foo', 'body' => 'FOO BAR'],
                 'subcustom_collection' => [
-                    ['title' => 'Item 1 title', 'body' => 'ITEM 1 BODY'],
-                    ['title' => 'Item 2 title', 'body' => 'ITEM 2 BODY'],
+                    5 => ['title' => 'Item 1 title', 'body' => 'ITEM 1 BODY'],
+                    17 => ['title' => 'Item 2 title', 'body' => 'ITEM 2 BODY'],
                 ],
             ],
             $customForm->getFieldValues()


### PR DESCRIPTION
Okay. Attempt # 3 for collection items' `alterFieldValues()` :|

The bug is which collection items keys to alter. Children are 0-indexed, input data is custom keyed. It only worked for data that was also 0-indexed, like the test was, which is why it passed.

The horror in `CollectionType::alterFieldValues()` finds the `$itemKey` from the child name, instead of using the children index `$i`.

I haven't tested for non-form collections. Maybe I should do that.