### PR TITLE
accept closure attributes (eg wrapper.class)

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -323,13 +323,13 @@ abstract class FormField
             }
         }
 
-        $this->setOption('wrapperAttrs', $helper->prepareAttributes($this->getOption('wrapper')));
-        $this->setOption('errorAttrs', $helper->prepareAttributes($this->getOption('errors')));
+        $this->setOption('wrapperAttrs', $helper->prepareAttributes($this->getOption('wrapper'), $this));
+        $this->setOption('errorAttrs', $helper->prepareAttributes($this->getOption('errors'), $this));
 
         if ($this->getOption('help_block.text')) {
             $this->setOption(
                 'help_block.helpBlockAttrs',
-                $helper->prepareAttributes($this->getOption('help_block.attr'))
+                $helper->prepareAttributes($this->getOption('help_block.attr'), $this)
             );
         }
 

--- a/src/Kris/LaravelFormBuilder/FormHelper.php
+++ b/src/Kris/LaravelFormBuilder/FormHelper.php
@@ -188,7 +188,7 @@ class FormHelper
      * @param $options
      * @return string
      */
-    public function prepareAttributes($options)
+    public function prepareAttributes($options, ...$optionalArguments)
     {
         if (!$options) {
             return null;
@@ -199,7 +199,7 @@ class FormHelper
         foreach ($options as $name => $option) {
             if ($option !== null) {
                 $name = is_numeric($name) ? $option : $name;
-                $attributes[] = $name . '="' . $option . '" ';
+                $attributes[] = $name . '="' . value($option, ...$optionalArguments) . '" ';
             }
         }
 

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -110,6 +110,30 @@ namespace {
         }
 
         /** @test */
+        public function it_can_assign_dynamic_classes_to_child_forms()
+        {
+            $items = new \Illuminate\Support\Collection([
+                (new DummyEloquentModel2())->forceFill(['id' => 1, 'foo' => 'a']),
+                (new DummyEloquentModel2())->forceFill(['id' => 2, 'foo' => 'b']),
+                (new DummyEloquentModel2())->forceFill(['id' => 3, 'foo' => 'c']),
+            ]);
+
+            $model = (new DummyEloquentModel())->forceFill(['id' => 11]);
+            $model->setRelation('items', $items);
+
+            $form = $this->formBuilder->create('LaravelFormBuilderCollectionTypeTest\Forms\WithDynamicAttributesFormCollectionForm', [
+                'model' => $model,
+            ]);
+
+            $html = $form->renderForm();
+
+            $timesAlwaysClass = count(explode('always-class', $html)) - 1;
+            $timesOnceClass = count(explode('once-class', $html)) - 1;
+            $this->assertEquals(3, $timesAlwaysClass);
+            $this->assertEquals(1, $timesOnceClass);
+        }
+
+        /** @test */
         public function it_creates_collection_with_child_form_with_correct_model()
         {
             $model = new DummyEloquentModel();
@@ -338,6 +362,30 @@ namespace LaravelFormBuilderCollectionTypeTest\Forms {
                 },
                 'options' => [
                     'class' => NamespacedDummyFormCollectionChildForm::class,
+                ],
+            ]);
+        }
+    }
+
+    class WithDynamicAttributesFormCollectionForm extends Form
+    {
+        function buildForm()
+        {
+            $this->add('items', 'collection', [
+                'type' => 'form',
+                'prototype' => false,
+                'empty_row' => false,
+                'options' => [
+                    'class' => NamespacedDummyFormCollectionChildForm::class,
+                    'wrapper' => [
+                        'class' => function(\Kris\LaravelFormBuilder\Fields\FormField $field) {
+                            $form = $field->getForm();
+                            $model = $form ? $form->getModel() : null;
+                            $id = $model ? $model->id : 0;
+                            $onceClass = $id == 2 ? 'once-class' : '';
+                            return "always-class $onceClass";
+                        },
+                    ],
                 ],
             ]);
         }


### PR DESCRIPTION
This change accepts attributes to be closures (resolved by Laravel's `value()`). That's not useful for most fields, because all context is present where the field is defined. But it is useful for `collection` fields, because you define the same attributes for all the items/child forms. This way you can dynamically add different attributes for different items:

```

class ParentForm {
	function buildForm() {
		$this->add('items', 'collection', [
			'type' => 'form',
			'prototype' => false,
			'empty_model' => fn() => new ChildModel,
			'options' => [
				'class' => ChildForm::class,
				'wrapper' => [
					// current
					'class' => 'non-dynamic class',
					// new, optional
					'class' => function(\Kris\LaravelFormBuilder\Fields\FormField $field) {
						return 'use $field to add dynamic class';
					},
				],
			],
		]);
	}
}
```

I use this to highlight some collection items if they contain problems.

`$field` is the collection item field. In this case a `ChildFormType` because `type = form`. It could be a `InputType`, which doesn't have a `getForm(I`