### PR TITLE
label_template option

### DIFF
--- a/src/views/checkbox.php
+++ b/src/views/checkbox.php
@@ -7,8 +7,10 @@
 <?php if ($showField): ?>
     <?= Form::checkbox($name, $options['value'], $options['checked'], $options['attr']) ?>
 
-    <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-        <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+        <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+        <?php include 'label.php' ?>
     <?php endif; ?>
 
     <?php include 'help_block.php' ?>

--- a/src/views/child_form.php
+++ b/src/views/child_form.php
@@ -4,8 +4,10 @@
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+<?= view($options['label_template'], get_defined_vars())->render(); ?>
+<?php else: ?>
+<?php include 'label.php' ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/choice.php
+++ b/src/views/choice.php
@@ -4,8 +4,10 @@
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+<?= view($options['label_template'], get_defined_vars())->render(); ?>
+<?php else: ?>
+<?php include 'label.php' ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/collection.php
+++ b/src/views/collection.php
@@ -4,8 +4,10 @@
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+<?= view($options['label_template'], get_defined_vars())->render(); ?>
+<?php else: ?>
+<?php include 'label.php' ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/label.php
+++ b/src/views/label.php
@@ -1,0 +1,3 @@
+<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
+    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php endif; ?>

--- a/src/views/radio.php
+++ b/src/views/radio.php
@@ -7,8 +7,10 @@
 <?php if ($showField): ?>
     <?= Form::radio($name, $options['value'], $options['checked'], $options['attr']) ?>
 
-    <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-        <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+    <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+    <?php include 'label.php' ?>
     <?php endif; ?>
 
     <?php include 'help_block.php' ?>

--- a/src/views/select.php
+++ b/src/views/select.php
@@ -4,8 +4,10 @@
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+<?= view($options['label_template'], get_defined_vars())->render(); ?>
+<?php else: ?>
+<?php include 'label.php' ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/static.php
+++ b/src/views/static.php
@@ -4,8 +4,10 @@
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+<?= view($options['label_template'], get_defined_vars())->render(); ?>
+<?php else: ?>
+<?php include 'label.php' ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/text.php
+++ b/src/views/text.php
@@ -4,8 +4,10 @@
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+<?= view($options['label_template'], get_defined_vars())->render(); ?>
+<?php else: ?>
+<?php include 'label.php' ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/textarea.php
+++ b/src/views/textarea.php
@@ -4,8 +4,10 @@
     <?php endif; ?>
 <?php endif; ?>
 
-<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+<?= view($options['label_template'], get_defined_vars())->render(); ?>
+<?php else: ?>
+<?php include 'label.php' ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Kris\LaravelFormBuilder\Form;
 use Kris\LaravelFormBuilder\FormHelper;
 use Kris\LaravelFormBuilder\Fields\InputType;
 
@@ -335,4 +334,19 @@ class FormFieldTest extends FormBuilderTestCase
         $testField->clearFilters();
         $this->assertEmpty($testField->getFilters());
     }
+
+    /** @test */
+    public function text_label_template()
+    {
+        $options = [
+            'label' => 'Name',
+            'label_show' => true,
+            'label_template' => 'laravel-form-builder-test::test-label',
+        ];
+        $field = new InputType('name', 'text', $this->plainForm, $options);
+
+        $view = $field->render();
+        $this->assertRegExp('/test label view/', $view);
+    }
+
 }

--- a/tests/Fields/InputTypeTest.php
+++ b/tests/Fields/InputTypeTest.php
@@ -40,9 +40,9 @@ class InputTypeTest extends FormBuilderTestCase
     public function it_handles_default_values()
     {
         $options = [
-            'default_value' => 100
+            'default_value' => 100,
+            'model' => null,
         ];
-        $this->plainForm->setModel(null);
         $input = new InputType('test', 'text', $this->plainForm, $options);
 
         $this->assertEquals(100, $input->getOption('value'));

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -79,6 +79,9 @@ abstract class FormBuilderTestCase extends TestCase {
     {
         parent::setUp();
 
+        // add views for testing
+        $this->app['view']->addNamespace('laravel-form-builder-test', __DIR__ . '/resources/views');
+
         $this->view = $this->app['view'];
         $this->translator = $this->app['translator'];
         $this->request = $this->app['request'];

--- a/tests/resources/views/test-label.php
+++ b/tests/resources/views/test-label.php
@@ -1,0 +1,4 @@
+<?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
+    <!-- test label view -->
+    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+<?php endif; ?>


### PR DESCRIPTION
new option for label template (`label_template`) and moved rendering label to label.php template file for all templates with label.

It simplifies extension of lable only for all fields or just for single specified field without extending all fields templates.