### PR TITLE
label_template option

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,9 @@
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./tests/</directory>
+            <exclude>
+                <directory>./tests/resources/views</directory>
+            </exclude>
         </testsuite>
     </testsuites>
     <coverage>

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -37,6 +37,14 @@ if(!function_exists('helpBlockPath'))
 
 }
 
+if (!function_exists('labelBlockPath'))
+{
+    function labelBlockPath()
+    {
+        return getFormBuilderViewPath('label.php');
+    }
+}
+
 if (!function_exists('form')) {
 
     function form(Form $form, array $options = [])

--- a/src/views/checkbox.php
+++ b/src/views/checkbox.php
@@ -7,8 +7,13 @@
 <?php if ($showField): ?>
     <?= Form::checkbox($name, $options['value'], $options['checked'], $options['attr']) ?>
 
+    <?php /** label rendering section */ ?>
     <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-        <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+        <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+            <?= view($options['label_template'], get_defined_vars())->render(); ?>
+        <?php else: ?>
+            <?php include labelBlockPath(); ?>
+        <?php endif; ?>
     <?php endif; ?>
 
     <?php include helpBlockPath(); ?>

--- a/src/views/child_form.php
+++ b/src/views/child_form.php
@@ -4,8 +4,13 @@
     <?php endif; ?>
 <?php endif; ?>
 
+<?php /** label rendering section */ ?>
 <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+        <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+        <?php include labelBlockPath(); ?>
+    <?php endif; ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/choice.php
+++ b/src/views/choice.php
@@ -4,8 +4,13 @@
     <?php endif; ?>
 <?php endif; ?>
 
+<?php /** label rendering section */ ?>
 <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+        <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+        <?php include labelBlockPath(); ?>
+    <?php endif; ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/collection.php
+++ b/src/views/collection.php
@@ -4,8 +4,13 @@
     <?php endif; ?>
 <?php endif; ?>
 
+<?php /** label rendering section */ ?>
 <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+        <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+        <?php include labelBlockPath(); ?>
+    <?php endif; ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/label.php
+++ b/src/views/label.php
@@ -1,0 +1,1 @@
+<?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>

--- a/src/views/radio.php
+++ b/src/views/radio.php
@@ -7,8 +7,13 @@
 <?php if ($showField): ?>
     <?= Form::radio($name, $options['value'], $options['checked'], $options['attr']) ?>
 
+    <?php /** label rendering section */ ?>
     <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-        <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+        <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+            <?= view($options['label_template'], get_defined_vars())->render(); ?>
+        <?php else: ?>
+            <?php include labelBlockPath(); ?>
+        <?php endif; ?>
     <?php endif; ?>
 
     <?php include helpBlockPath(); ?>

--- a/src/views/select.php
+++ b/src/views/select.php
@@ -4,8 +4,13 @@
     <?php endif; ?>
 <?php endif; ?>
 
+<?php /** label rendering section */ ?>
 <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+        <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+        <?php include labelBlockPath(); ?>
+    <?php endif; ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/static.php
+++ b/src/views/static.php
@@ -4,8 +4,13 @@
     <?php endif; ?>
 <?php endif; ?>
 
+<?php /** label rendering section */ ?>
 <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+        <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+        <?php include labelBlockPath(); ?>
+    <?php endif; ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/text.php
+++ b/src/views/text.php
@@ -4,8 +4,13 @@
     <?php endif; ?>
 <?php endif; ?>
 
+<?php /** label rendering section */ ?>
 <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+        <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+        <?php include labelBlockPath(); ?>
+    <?php endif; ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/src/views/textarea.php
+++ b/src/views/textarea.php
@@ -4,8 +4,13 @@
     <?php endif; ?>
 <?php endif; ?>
 
+<?php /** label rendering section */ ?>
 <?php if ($showLabel && $options['label'] !== false && $options['label_show']): ?>
-    <?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>
+    <?php if(array_key_exists('label_template', $options) && $options['label_template']): ?>
+        <?= view($options['label_template'], get_defined_vars())->render(); ?>
+    <?php else: ?>
+        <?php include labelBlockPath(); ?>
+    <?php endif; ?>
 <?php endif; ?>
 
 <?php if ($showField): ?>

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -298,12 +298,11 @@ class FormFieldTest extends FormBuilderTestCase
         );
     }
 
-    /**
-     * @test
-     * @expectedException \Kris\LaravelFormBuilder\Filters\Exception\FilterAlreadyBindedException
-     */
+    /** @test  */
     public function it_throws_an_exception_if_filters_override_is_false_but_passed_already_binded_filter()
     {
+        $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\FilterAlreadyBindedException::class);
+
         $customPlainForm = $this->formBuilder->plain();
         $customPlainForm->add('test_field', 'text', [
             'filters' => ['Trim']

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -300,11 +300,10 @@ class FormFieldTest extends FormBuilderTestCase
 
     /**
      * @test
+     * @expectedException \Kris\LaravelFormBuilder\Filters\Exception\FilterAlreadyBindedException
      */
     public function it_throws_an_exception_if_filters_override_is_false_but_passed_already_binded_filter()
     {
-        $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\FilterAlreadyBindedException::class);
-
         $customPlainForm = $this->formBuilder->plain();
         $customPlainForm->add('test_field', 'text', [
             'filters' => ['Trim']
@@ -403,6 +402,94 @@ class FormFieldTest extends FormBuilderTestCase
 
         $this->assertTrue($method->invokeArgs($customPlainForm, []));
     }
+
+    /** @test */
+    public function label_template()
+    {
+        $fieldsOptions = [
+            [
+                'type' => 'checkbox',
+                'name' => 'checkbox_field',
+                'options' => [
+                    'label' => 'Checkbox Field #1',
+                    'label_show' => true,
+                    'label_template' => 'laravel-form-builder-test::test-label',
+                ]
+            ],
+            [
+                'type' => 'choice',
+                'name' => 'choide_field',
+                'options' => [
+                    'label' => 'Choice Field #1',
+                    'choices' => [true => 'Yes', false => 'No'],
+                    'label_show' => true,
+                    'label_template' => 'laravel-form-builder-test::test-label',
+                ]
+            ],
+            [
+                'type' => 'collection',
+                'name' => 'collection_field',
+                'options' => [
+                    'label' => 'Collection Field #1',
+                    'label_show' => true,
+                    'label_template' => 'laravel-form-builder-test::test-label',
+                ]
+            ],
+            [
+                'type' => 'radio',
+                'name' => 'radio_field',
+                'options' => [
+                    'label' => 'Radio Field #1',
+                    'label_show' => true,
+                    'label_template' => 'laravel-form-builder-test::test-label',
+                ]
+            ],
+            [
+                'type' => 'select',
+                'name' => 'select_field',
+                'options' => [
+                    'label' => 'Select Field #1',
+                    'label_show' => true,
+                    'label_template' => 'laravel-form-builder-test::test-label',
+                ]
+            ],
+            [
+                'type' => 'static',
+                'name' => 'static_field',
+                'options' => [
+                    'label' => 'Static Field #1',
+                    'label_show' => true,
+                    'label_template' => 'laravel-form-builder-test::test-label',
+                ]
+            ],
+            [
+                'type' => 'text',
+                'name' => 'text_field',
+                'options' => [
+                    'label' => 'Text Field #1',
+                    'label_show' => true,
+                    'label_template' => 'laravel-form-builder-test::test-label',        
+                ]
+            ],
+            [
+                'type' => 'textarea',
+                'name' => 'textarea_field',
+                'options' => [
+                    'label' => 'Textarea Field #1',
+                    'label_show' => true,
+                    'label_template' => 'laravel-form-builder-test::test-label',        
+                ]
+            ],
+        
+        ];
+
+        foreach ($fieldsOptions as $config) {
+            $field = new InputType($config['name'] ?? 'name', $config['type'], $this->plainForm, $config['options']);
+            $view = $field->render();
+            $this->assertMatchesRegularExpression('/test label view/', $view);
+        }
+    }
+
 }
 
 

--- a/tests/Fields/InputTypeTest.php
+++ b/tests/Fields/InputTypeTest.php
@@ -40,9 +40,9 @@ class InputTypeTest extends FormBuilderTestCase
     public function it_handles_default_values()
     {
         $options = [
-            'default_value' => 100
+            'default_value' => 100,
+            'model' => null,
         ];
-        $this->plainForm->setModel(null);
         $input = new InputType('test', 'text', $this->plainForm, $options);
 
         $this->assertEquals(100, $input->getOption('value'));

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -185,6 +185,8 @@ abstract class FormBuilderTestCase extends TestCase {
         parent::setUp();
 
         $this->withoutDeprecationHandling();
+        // add views for testing
+        $this->app['view']->addNamespace('laravel-form-builder-test', __DIR__ . '/resources/views');
 
         $this->view = $this->app['view'];
         $this->translator = $this->app['translator'];

--- a/tests/resources/views/test-label.php
+++ b/tests/resources/views/test-label.php
@@ -1,0 +1,2 @@
+<!-- test label view -->
+<?= Form::customLabel($name, $options['label'], $options['label_attr']) ?>


### PR DESCRIPTION
new option for label template and moved rendering label to `label.php` template file for all templates with label. It simplifies extension of way label is rendered and allows to add custom html to labels. Works for every field (by extending `label.php` file) or for individual field (by providing `label_template` value pointing proper template file).