### PR TITLE
ParentType  disable()/enable() fix

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -211,7 +211,7 @@ class CollectionType extends ParentType
 
         $firstFieldOptions = $this->formHelper->mergeOptions(
             $this->getOption('options'),
-            ['attr' => ['id' => $newFieldName]]
+            ['attr' => array_merge(['id' => $newFieldName], $this->getOption('attr'))]
         );
 
         $field->setName($newFieldName);

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -753,7 +753,7 @@ abstract class FormField
     /**
      * Get validation rules for a field if any with label for attributes.
      *
-     * @return array|null
+     * @return Rules
      */
     public function getValidationRules()
     {

--- a/src/Kris/LaravelFormBuilder/Fields/ParentType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/ParentType.php
@@ -175,9 +175,11 @@ abstract class ParentType extends FormField
      */
     public function disable()
     {
+        parent::disable();
         foreach ($this->children as $field) {
             $field->disable();
         }
+        return $this;
     }
 
     /**
@@ -185,9 +187,11 @@ abstract class ParentType extends FormField
      */
     public function enable()
     {
+        parent::enable();
         foreach ($this->children as $field) {
             $field->enable();
         }
+        return $this;
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -24,7 +24,23 @@ return [
         //        'wrapper'     => ['class' => 'form-radio'],
         //        'label'       => ['class' => 'form-radio-label'],
         //        'field'       => ['class' => 'form-radio-field'],
+        //    ]
         //],
+        // 
+        // 'choice'             => [
+        //    'choice_options'  => [
+        //        'wrapper_class'  => 'choice-wrapper-class',
+        //        'label_class'    => 'choice-label-class',
+        //        'field_class'    => 'choice-field-class'
+        //
+        //        # For choice type you may overwrite default choice options for each variant (checkbox, radio or select)
+        //        'checkbox'       => [
+        //            'wrapper_class' => 'choice-checkbox-wrapper-class',
+        //            'label_class'   => 'choice-checkbox-label-class',
+        //            'field_class'   => 'choice-checkbox-field-class',
+        //        ]
+        //    ]
+        //]
     ],
     // Templates
     'form'          => 'laravel-form-builder::form',

--- a/tests/Fields/ChoiceTypeTest.php
+++ b/tests/Fields/ChoiceTypeTest.php
@@ -106,4 +106,185 @@ class ChoiceTypeTest extends FormBuilderTestCase
 
         $this->assertEquals('test', $choice->getOption('selected'));
     }
+
+    /** @test */
+    public function it_disables_select()
+    {
+        $options = [
+            'attr' => ['class' => 'choice-class'],
+            'choices' => ['yes' => 'Yes', 'no' => 'No'],
+            'selected' => 'yes'
+        ];
+        $field = new ChoiceType('some_choice', 'choice', $this->plainForm, $options);
+        $children = $field->getChildren();
+        
+        // there shall be no 'disabled' attribute set beforehand
+        $this->assertArrayNotHasKey('disabled', $field->getOption('attr'));
+        foreach ($children as $child) {
+            $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+        }
+
+        $field->disable();
+
+        // there shall be 'disabled' attribute set after
+        $this->assertArrayHasKey('disabled', $field->getOption('attr'));
+        $this->assertEquals('disabled', $field->getOption('attr')['disabled']);
+        foreach ($children as $child) {
+            $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+            $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+        }
+    }
+
+    /** @test */
+    public function it_disables_checkbox_list()
+    {
+        $options = [
+            'attr' => ['class' => 'choice-class-something'],
+            'choices' => [1 => 'monday', 2 => 'tuesday'],
+            'selected' => 'tuesday',
+            'multiple' => true,
+            'expanded' => true
+        ];
+
+        $field = new ChoiceType('some_choice', 'choice', $this->plainForm, $options);
+        $children = $field->getChildren();
+
+        // there shall be no 'disabled' attribute set beforehand
+        $this->assertArrayNotHasKey('disabled', $field->getOption('attr'));
+        foreach ($children as $child) {
+            $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+        }
+
+        $field->disable();
+
+        // there shall be 'disabled' attribute set after
+        $this->assertArrayHasKey('disabled', $field->getOption('attr'));
+        $this->assertEquals('disabled', $field->getOption('attr')['disabled']);
+        foreach ($children as $child) {
+            $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+            $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+        }
+    }
+    
+    /** @test */
+    public function it_disables_radios_list()
+    {
+        $options = [
+            'attr' => ['class' => 'choice-class-something'],
+            'choices' => [1 => 'yes', 2 => 'no'],
+            'selected' => 'no',
+            'expanded' => true
+        ];
+
+        $field = new ChoiceType('some_choice', 'choice', $this->plainForm, $options);
+        $children = $field->getChildren();
+
+        // there shall be no 'disabled' attribute set beforehand
+        $this->assertArrayNotHasKey('disabled', $field->getOption('attr'));
+        foreach ($children as $child) {
+            $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+        }
+
+        $field->disable();
+
+        // there shall be 'disabled' attribute set after
+        $this->assertArrayHasKey('disabled', $field->getOption('attr'));
+        $this->assertEquals('disabled', $field->getOption('attr')['disabled']);
+        foreach ($children as $child) {
+            $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+            $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+        }
+    }
+    
+    /** @test */
+    public function it_enables_select()
+    {
+        $options = [
+            'attr' => ['class' => 'choice-class', 'disabled' => 'disabled'],
+            'choices' => ['yes' => 'Yes', 'no' => 'No'],
+            'selected' => 'yes'
+        ];
+        $field = new ChoiceType('some_choice', 'choice', $this->plainForm, $options);
+        $children = $field->getChildren();
+
+        // there shall be 'disabled' attribute set beforehand
+        $this->assertArrayHasKey('disabled', $field->getOption('attr'));
+        $this->assertEquals('disabled', $field->getOption('attr')['disabled']);
+        foreach ($children as $child) {
+            $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+            $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+        }
+
+
+        $field->enable();
+
+        // there shall be no 'disabled' attribute set after
+        $this->assertArrayNotHasKey('disabled', $field->getOption('attr'));
+        foreach ($children as $child) {
+            $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+        }
+    }
+
+    /** @test */
+    public function it_enables_checkbox_list()
+    {
+        $options = [
+            'attr' => ['class' => 'choice-class-something', 'disabled' => 'disabled'],
+            'choices' => [1 => 'monday', 2 => 'tuesday'],
+            'selected' => 'tuesday',
+            'multiple' => true,
+            'expanded' => true
+        ];
+
+        $field = new ChoiceType('some_choice', 'choice', $this->plainForm, $options);
+        $children = $field->getChildren();
+
+        // there shall be 'disabled' attribute set beforehand
+        $this->assertArrayHasKey('disabled', $field->getOption('attr'));
+        $this->assertEquals('disabled', $field->getOption('attr')['disabled']);
+        foreach ($children as $child) {
+            $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+            $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+        }
+
+
+        $field->enable();
+
+        // there shall be no 'disabled' attribute set after
+        $this->assertArrayNotHasKey('disabled', $field->getOption('attr'));
+        foreach ($children as $child) {
+            $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+        }
+    }
+    
+    /** @test */
+    public function it_enables_radios_list()
+    {
+        $options = [
+            'attr' => ['class' => 'choice-class-something', 'disabled' => 'disabled'],
+            'choices' => [1 => 'yes', 2 => 'no'],
+            'selected' => 'no',
+            'expanded' => true
+        ];
+
+        $field = new ChoiceType('some_choice', 'choice', $this->plainForm, $options);
+        $children = $field->getChildren();
+
+        // there shall be 'disabled' attribute set beforehand
+        $this->assertArrayHasKey('disabled', $field->getOption('attr'));
+        $this->assertEquals('disabled', $field->getOption('attr')['disabled']);
+        foreach ($children as $child) {
+            $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+            $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+        }
+
+
+        $field->enable();
+
+        // there shall be no 'disabled' attribute set after
+        $this->assertArrayNotHasKey('disabled', $field->getOption('attr'));
+        foreach ($children as $child) {
+            $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+        }
+    }
 }

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -297,6 +297,55 @@ namespace {
             }
         }
 
+        /** @test */
+        public function it_disables()
+        {
+            $options = [
+                'type' => 'text'
+            ];
+            $emailsCollection = new CollectionType('emails', 'collection', $this->plainForm, $options);
+            $children = $emailsCollection->getChildren();
+
+            $this->assertArrayNotHasKey('disabled', $emailsCollection->getOption('attr'));
+            foreach ($children as $child) {
+                $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+            }
+
+            $emailsCollection->disable();
+
+            $this->assertArrayHasKey('disabled', $emailsCollection->getOption('attr'));
+            $this->assertEquals('disabled', $emailsCollection->getOption('attr')['disabled']);
+            foreach ($children as $child) {
+                $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+                $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+            }
+        }
+        
+        /** @test */
+        public function it_enables()
+        {
+            $options = [
+                'type' => 'text',
+                'attr' => ['disabled' => 'disabled'],
+            ];
+            $collection = new CollectionType('emails', 'collection', $this->plainForm, $options);
+            $children = $collection->getChildren();
+
+            $this->assertArrayHasKey('disabled', $collection->getOption('attr'));
+            $this->assertEquals('disabled', $collection->getOption('attr')['disabled']);
+            foreach ($children as $child) {
+                $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+                $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+            }
+
+            $collection->enable();
+
+            $this->assertArrayNotHasKey('disabled', $collection->getOption('attr'));
+            foreach ($children as $child) {
+                $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+            }
+        }
+
     }
 
     class DummyEloquentModel extends Model {

--- a/tests/Fields/EntityTypeTest.php
+++ b/tests/Fields/EntityTypeTest.php
@@ -92,12 +92,68 @@ class EntityTypeTest extends FormBuilderTestCase
         $choice->setOption('attr.data-key', 'value');
 
         $field = $choice->render();
-
+        
         $expectedField = '<div class="form-group">
             <label for="entity_choice" class="control-label">Entity choice</label>
             <select class="form-control" data-key="value" id="entity_choice" name="entity_choice"><option value="1">English</option><option value="2">French</option><option value="3">Serbian</option></select>
-        </div>';
+            </div>';
+            
+            $this->assertXmlStringEqualsXmlString(trim($field), $expectedField);
+        }
 
-        $this->assertXmlStringEqualsXmlString(trim($field), $expectedField);
+    /** @test */
+    public function it_disables()
+    {
+        $choices = ['yes' => 'Yes', 'no' => 'No'];
+        $options = [
+            'attr' => ['class' => 'choice-class'],
+            'choices' => $choices,
+            'selected' => 'yes'
+        ];
+
+        $choice = new EntityType('some_entity', 'entity', $this->plainForm, $options);
+        $children = $choice->getChildren();
+
+        $this->assertArrayNotHasKey('disabled', $choice->getOption('attr'));
+        foreach ($children as $child) {
+            $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+        }
+
+        $choice->disable();
+
+        $this->assertArrayHasKey('disabled', $choice->getOption('attr'));
+        $this->assertEquals('disabled', $choice->getOption('attr')['disabled']);
+        foreach ($children as $child) {
+            $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+            $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+        }
+    }
+    
+    /** @test */
+    public function it_enables()
+    {
+        $choices = ['yes' => 'Yes', 'no' => 'No'];
+        $options = [
+            'attr' => ['class' => 'choice-class', 'disabled' => 'disabled'],
+            'choices' => $choices,
+            'selected' => 'yes'
+        ];
+
+        $choice = new EntityType('some_entity', 'entity', $this->plainForm, $options);
+        $children = $choice->getChildren();
+
+        $this->assertArrayHasKey('disabled', $choice->getOption('attr'));
+        $this->assertEquals('disabled', $choice->getOption('attr')['disabled']);
+        foreach ($children as $child) {
+            $this->assertArrayHasKey('disabled', $child->getOption('attr'));
+            $this->assertEquals('disabled', $child->getOption('attr')['disabled']);
+        }
+
+        $choice->enable();
+
+        $this->assertArrayNotHasKey('disabled', $choice->getOption('attr'));
+        foreach ($children as $child) {
+            $this->assertArrayNotHasKey('disabled', $child->getOption('attr'));
+        }
     }
 }


### PR DESCRIPTION
Fields extending `ParentType` don't act properly when disabled. For example `ChoiceType` with `required` rule is not disabled even if asked nicely with `disable()` method. This is due to fact `attr` option gets copied to children from parent while rendering but it doesn't contain `disabled` attribute after `disable()` method was called.

Fixed `disable()` and `enable()` method to act upon `ParentType` field itself before populating information to children. Added functionality tests to all derivatives (as ParentType is abstract and has no tests written so far).

Don't know why it ads some code from previous PR that was already merged. Those changes were made during Pull Request review.