### PR TITLE
Allow collection option label to be a callback for dynamic child label

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -36,6 +36,7 @@ class CollectionType extends ParentType
             'type' => null,
             'options' => ['is_child' => true],
             'prototype' => true,
+            'label_callback' => null,
             'data' => null,
             'property' => 'id',
             'prototype_name' => '__NAME__',
@@ -249,6 +250,9 @@ class CollectionType extends ParentType
 
         $field->setValue($value);
 
+        if ($callback = $this->getOption('label_callback')) {
+            $field->setOption('label', value($callback, $value, $field));
+        }
 
         return $field;
     }

--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -36,7 +36,6 @@ class CollectionType extends ParentType
             'type' => null,
             'options' => ['is_child' => true],
             'prototype' => true,
-            'label_callback' => null,
             'data' => null,
             'property' => 'id',
             'prototype_name' => '__NAME__',
@@ -238,8 +237,8 @@ class CollectionType extends ParentType
             ['attr' => array_merge(['id' => $newFieldName], $this->getOption('attr'))]
         );
 
-        if ($callback = $this->getOption('label_callback')) {
-            $firstFieldOptions['label'] = value($callback, $value, $field);
+        if (isset($firstFieldOptions['label'])) {
+            $firstFieldOptions['label'] = value($firstFieldOptions['label'], $value, $field);
         }
 
         $field->setName($newFieldName);

--- a/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
+++ b/src/Kris/LaravelFormBuilder/Fields/CollectionType.php
@@ -238,6 +238,10 @@ class CollectionType extends ParentType
             ['attr' => array_merge(['id' => $newFieldName], $this->getOption('attr'))]
         );
 
+        if ($callback = $this->getOption('label_callback')) {
+            $firstFieldOptions['label'] = value($callback, $value, $field);
+        }
+
         $field->setName($newFieldName);
         $field->setOptions($firstFieldOptions);
 
@@ -249,10 +253,6 @@ class CollectionType extends ParentType
         }
 
         $field->setValue($value);
-
-        if ($callback = $this->getOption('label_callback')) {
-            $field->setOption('label', value($callback, $value, $field));
-        }
 
         return $field;
     }


### PR DESCRIPTION
Collection children don't have a label by default, but an automatic label is assigned anyway. You can already assign specific labels after creating the collection field:

```php
foreach ($this->getField('settings_collection')->getChildren() as $formfield) {
	$formfield->setOption('label', $formfield->getForm()->getModel()->name);
}
```

but that's not pretty. Much prettier is a callback in the collection options:

```php
$this->add('settings_collection', 'collection', [
	'label' => "Settings",
	'type' => 'form',
	'prototype' => false,
	'empty_row' => false,
	'options' => [
		'class' => MySettingForm::class,
		'label' => function(MySetting $setting, ChildFormType $formfield) {
			return $setting->name;
		},
	],
]);
```