### PR TITLE
Revert #725 - Registering customLabel macro once Form resolved

### DIFF
--- a/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
+++ b/src/Kris/LaravelFormBuilder/FormBuilderServiceProvider.php
@@ -7,8 +7,8 @@ use Collective\Html\FormBuilder as LaravelForm;
 use Collective\Html\HtmlBuilder;
 use Illuminate\Support\ServiceProvider;
 use InvalidArgumentException;
-use Kris\LaravelFormBuilder\Form;
 use Kris\LaravelFormBuilder\Traits\ValidatesWhenResolved;
+use Kris\LaravelFormBuilder\Form;
 
 class FormBuilderServiceProvider extends ServiceProvider
 {
@@ -105,15 +105,15 @@ class FormBuilderServiceProvider extends ServiceProvider
             __DIR__ . '/../../config/config.php' => config_path('laravel-form-builder.php')
         ]);
 
-        $this->app->afterResolving(static::FORM_ABSTRACT, function (LaravelForm $form) {
-            $form->macro('customLabel', function($name, $value, $options = [], $escapeHtml = true) use ($form) {
-                if (isset($options['for']) && $for = $options['for']) {
-                    unset($options['for']);
-                    return $form->label($for, $value, $options, $escapeHtml);
-                }
+        $form = $this->app[static::FORM_ABSTRACT];
 
-                return $form->label($name, $value, $options, $escapeHtml);
-            });
+        $form->macro('customLabel', function($name, $value, $options = [], $escape_html = true) use ($form) {
+            if (isset($options['for']) && $for = $options['for']) {
+                unset($options['for']);
+                return $form->label($for, $value, $options, $escape_html);
+            }
+
+            return $form->label($name, $value, $options, $escape_html);
         });
     }
 


### PR DESCRIPTION
#725

@rudiedirkx It is working fine in our latest code with Laravel 10, but I got some reports that it doesn't work for old versions (which using Laravel 9).

![image](https://github.com/kristijanhusak/laravel-form-builder/assets/6972407/2fb71582-d954-4429-bd02-49913b11f348)


I think this is a breaking change, we should not change this at this time.

Please revert it.