### PR TITLE
field (css class) defaults+

### DIFF
--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -675,7 +675,7 @@ abstract class FormField
         // Get default defaults from config (eg. defaults.field_class)
         $this->options = $this->formHelper->mergeOptions($this->allDefaults(), $this->getDefaults());
 
-        // Maybe overwrite with field type defaults from config (eg. defaults, checkbox, field_class)
+        // Maybe overwrite with field type defaults from config (eg. defaults.checkbox.field_class)
         $defaults = $this->setDefaultClasses($options);
         $this->options = $this->formHelper->mergeOptions($this->options, $defaults);
 

--- a/src/Kris/LaravelFormBuilder/Fields/FormField.php
+++ b/src/Kris/LaravelFormBuilder/Fields/FormField.php
@@ -406,7 +406,7 @@ abstract class FormField
      *
      * @param array $first first set of rules
      * @param array $second second set of rules
-     * @return array merged set of rules without duplicates 
+     * @return array merged set of rules without duplicates
      */
     protected function mergeRules($first, $second)
     {
@@ -672,11 +672,15 @@ abstract class FormField
      */
     protected function setDefaultOptions(array $options = [])
     {
+        // Get default defaults from config (eg. defaults.field_class)
         $this->options = $this->formHelper->mergeOptions($this->allDefaults(), $this->getDefaults());
-        $this->options = $this->prepareOptions($options);
 
+        // Maybe overwrite with field type defaults from config (eg. defaults, checkbox, field_class)
         $defaults = $this->setDefaultClasses($options);
         $this->options = $this->formHelper->mergeOptions($this->options, $defaults);
+
+        // Add specific field classes (eg. attr.class_append)
+        $this->options = $this->prepareOptions($options);
 
         $this->setupLabel();
     }

--- a/tests/Fields/CheckableTypeTest.php
+++ b/tests/Fields/CheckableTypeTest.php
@@ -21,7 +21,7 @@ class CheckableTypeTest extends FormBuilderTestCase
 
         $expectedOptions = $this->getDefaults(
             [
-                'class' => null,
+                'class' => 'custom-checkbox-field-class',
                 'required' => 'required',
                 'id' => 'test',
             ],

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -1,8 +1,9 @@
 <?php
 
 use Illuminate\Http\Request;
-use Kris\LaravelFormBuilder\FormHelper;
+use Kris\LaravelFormBuilder\Fields\CheckableType;
 use Kris\LaravelFormBuilder\Fields\InputType;
+use Kris\LaravelFormBuilder\FormHelper;
 
 class FormFieldTest extends FormBuilderTestCase
 {
@@ -117,13 +118,33 @@ class FormFieldTest extends FormBuilderTestCase
         $text = new InputType('field_name', 'text', $this->plainForm, $options);
         $renderResult = $text->render();
 
-        $this->assertMatchesRegularExpression('/appended/', $text->getOption('attr.class'));
+        $this->assertMatchesRegularExpression('/\bappended\b/', $text->getOption('attr.class'));
 
         $defaultClasses = $this->config['defaults']['field_class'];
         $this->assertEquals('form-control appended', $text->getOption('attr.class'));
 
         $this->assertStringContainsString($defaultClasses, $text->getOption('attr.class'));
         $this->assertStringNotContainsString('class_append', $renderResult);
+    }
+
+    /** @test */
+    public function it_appends_to_the_class_attribute_of_a_custom_classes_checkbox_field()
+    {
+        $options = [
+            'attr' => [
+                'class_append' => 'appended',
+            ],
+        ];
+
+        $text = new CheckableType('field_name', 'checkbox', $this->plainForm, $options);
+        $renderResult = $text->render();
+
+        $this->assertMatchesRegularExpression('/\bappended\b/', $text->getOption('attr.class'));
+
+        $this->assertEquals('custom-checkbox-field-class appended', $text->getOption('attr.class'));
+
+        $defaultClasses = $this->config['defaults']['field_class'];
+        $this->assertStringNotContainsString($defaultClasses, $text->getOption('attr.class'));
     }
 
     /** @test */
@@ -138,7 +159,7 @@ class FormFieldTest extends FormBuilderTestCase
         $text = new InputType('field_name', 'text', $this->plainForm, $options);
         $renderResult = $text->render();
 
-        $this->assertMatchesRegularExpression('/appended/', $text->getOption('label_attr.class'));
+        $this->assertMatchesRegularExpression('/\bappended\b/', $text->getOption('label_attr.class'));
 
         $defaultClasses = $this->config['defaults']['label_class'];
         $this->assertEquals('control-label appended', $text->getOption('label_attr.class'));
@@ -159,7 +180,7 @@ class FormFieldTest extends FormBuilderTestCase
         $text = new InputType('field_name', 'text', $this->plainForm, $options);
         $renderResult = $text->render();
 
-        $this->assertMatchesRegularExpression('/appended/', $text->getOption('wrapper.class'));
+        $this->assertMatchesRegularExpression('/\bappended\b/', $text->getOption('wrapper.class'));
 
         $defaultClasses = $this->config['defaults']['wrapper_class'];
         $this->assertEquals('form-group appended', $text->getOption('wrapper.class'));

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -199,7 +199,10 @@ abstract class FormBuilderTestCase extends TestCase {
         $this->validatorFactory = $this->app['validator'];
         $this->eventDispatcher = $this->app['events'];
         $this->model = new TestModel();
-        $this->config = include __DIR__.'/../src/config/config.php';
+
+        $config = include __DIR__.'/../src/config/config.php';
+        $config['defaults']['checkbox']['field_class'] = 'custom-checkbox-field-class';
+        $this->config = $config;
 
         $this->formHelper = new FormHelper($this->view, $this->translator, $this->config);
         $this->formBuilder = new FormBuilder($this->app, $this->formHelper, $this->eventDispatcher);

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -1230,8 +1230,8 @@ class FormTest extends FormBuilderTestCase
         $this->assertStringContainsString('<option value="zh" disabled="disabled">', $formView);
         $this->assertStringNotContainsString('<option value="en" disabled="disabled">', $formView);
         $this->assertStringNotContainsString('<option value="fr" disabled="disabled">', $formView);
-        $this->assertStringContainsString('<input id="languages_choice_checkbox_zh" disabled="disabled" name="languages_choice_checkbox[]" type="checkbox" value="zh">', $formView);
-        $this->assertStringNotContainsString('<input id="languages_choice_checkbox_en" disabled="disabled" name="languages_choice_checkbox[]" type="checkbox" value="en">', $formView);
+        $this->assertStringContainsString('<input class="custom-checkbox-field-class" id="languages_choice_checkbox_zh" disabled="disabled" name="languages_choice_checkbox[]" type="checkbox" value="zh">', $formView);
+        $this->assertStringNotContainsString('<input class="custom-checkbox-field-class" id="languages_choice_checkbox_en" disabled="disabled" name="languages_choice_checkbox[]" type="checkbox" value="en">', $formView);
         $this->assertStringContainsString('<input id="languages_choice_radio_zh" disabled="disabled" name="languages_choice_radio" type="radio" value="zh">', $formView);
         $this->assertStringNotContainsString('<input id="languages_choice_radio_en" disabled="disabled" name="languages_choice_radio" type="radio" value="en">', $formView);
     }


### PR DESCRIPTION
`class_append` didn't work for field types with specific config/classes.

Config:

```php
return [
	'defaults' => [
		'field_class'         => 'form-control',

		'checkbox' => [
			'field_class' 		=> 'form-check-input',
		],
	],
];
```

Add field:

```php
$this->add('mycheckbox', 'checkbox', [
	'label' => "Wadever",
	'attr' => ['class_append' => 'custom-checkbox'],
]);
```

That `<input>` would have `class="form-check-input"`, not `form-check-input custom-checkbox`, because `setDefaultClasses()` (with `form-check-input`) happened after `prepareOptions()` (with `class_append`/`custom-checkbox`), so the custom classes was added and then immediately overwritten.