### PR TITLE
Add support for laravel 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: "Run unit tests"
 on:
   - push
   - pull_request
+  - workflow_dispatch
 
 env:
   COMPOSER_MEMORY_LIMIT: -1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: "Run unit tests"
 on:
   - push
   - pull_request
-  - workflow_dispatch
 
 env:
   COMPOSER_MEMORY_LIMIT: -1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,13 +16,12 @@ jobs:
       max-parallel: 6 # 12
       fail-fast: false
       matrix:
-        laravel: [10, 11, 12]
-        php: ['8.2', '8.3', '8.4']
-        phpunit: [10, 11]
+        laravel: [12, 13]
+        php: ['8.2', '8.3', '8.4', '8.5']
+        phpunit: [11, 12]
         exclude:
-          - {laravel: 10, php: '8.4'}
-          - {laravel: 10, phpunit: 11}
-          - {laravel: 12, phpunit: 10}
+          - {laravel: 13, php: '8.2'}
+          - {php: '8.2', phpunit: 12}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require-dev": {
         "orchestra/testbench": "^10 || ^11",
-        "phpunit/phpunit": "^10.0 || ^11.0"
+        "phpunit/phpunit": "^11.5.50 || ^12.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,13 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "rdx/laravelcollective-html": "^6",
-        "illuminate/database": "^10 || ^11 || ^12",
-        "illuminate/validation": "^10 || ^11 || ^12"
+        "illuminate/database": "^12 || ^13",
+        "illuminate/validation": "^12 || ^13"
     },
     "require-dev": {
-        "orchestra/testbench": "^8 || ^9 || ^10",
+        "orchestra/testbench": "^10 || ^11",
         "phpunit/phpunit": "^10.0 || ^11.0"
     },
     "extra": {

--- a/tests/Console/FormGeneratorTest.php
+++ b/tests/Console/FormGeneratorTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kris\LaravelFormBuilder\Console\FormGenerator;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 class FormGeneratorTest extends TestCase
@@ -16,7 +17,7 @@ class FormGeneratorTest extends TestCase
         $this->formGenerator = new FormGenerator();
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_comment_when_no_fields_passed()
     {
         $parsedFields = $this->formGenerator->getFieldsVariable();
@@ -24,7 +25,7 @@ class FormGeneratorTest extends TestCase
         $this->assertEquals('// Add fields here...', $parsedFields);
     }
 
-    /** @test */
+    #[Test]
     public function it_parses_fields_from_options_to_methods()
     {
         $fields = 'first_name:text, last_name:text, user_email:email, user_password:password';
@@ -42,7 +43,7 @@ class FormGeneratorTest extends TestCase
         $this->assertSame($expected, $parsedFields);
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_class_info_for_given_full_class_name()
     {
         // Parsed in this format from Laravels GeneratorCommand

--- a/tests/Fields/ButtonGroupTypeTest.php
+++ b/tests/Fields/ButtonGroupTypeTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\ButtonGroupType;
+use PHPUnit\Framework\Attributes\Test;
 
 class ButtonGroupTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_creates_checkbox_field(): void
     {
         $defaultOptions = [
@@ -43,7 +44,7 @@ class ButtonGroupTypeTest extends FormBuilderTestCase
         $this->assertEquals($expectedOptions, $buttongroup->getOptions());
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_splitted(): void
     {
         $options = [
@@ -55,7 +56,7 @@ class ButtonGroupTypeTest extends FormBuilderTestCase
         $this->assertTrue($buttongroup->getOption('splitted'));
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_size(): void
     {
         $expectedValue = 'lg';
@@ -69,7 +70,7 @@ class ButtonGroupTypeTest extends FormBuilderTestCase
         $this->assertSame($expectedValue, $buttongroup->getOption('size'));
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_buttons(): void
     {
         $buttons = [

--- a/tests/Fields/ButtonTypeTest.php
+++ b/tests/Fields/ButtonTypeTest.php
@@ -2,11 +2,12 @@
 
 use Kris\LaravelFormBuilder\Fields\ButtonType;
 use Kris\LaravelFormBuilder\Form;
+use PHPUnit\Framework\Attributes\Test;
 
 class ButtonTypeTest extends FormBuilderTestCase
 {
 
-    /** @test */
+    #[Test]
     public function it_creates_button()
     {
         $options = [
@@ -26,7 +27,7 @@ class ButtonTypeTest extends FormBuilderTestCase
         $button->render();
     }
 
-    /** @test */
+    #[Test]
     public function it_can_handle_object_with_getters_and_setters()
     {
         $expectedOptions = $this->getDefaults(['type' => 'submit'], 'Save');
@@ -58,7 +59,7 @@ class ButtonTypeTest extends FormBuilderTestCase
         $this->assertTrue($button->isRendered());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_change_template_with_options()
     {
         $expectedOptions = $this->getDefaults(

--- a/tests/Fields/CheckableTypeTest.php
+++ b/tests/Fields/CheckableTypeTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\CheckableType;
+use PHPUnit\Framework\Attributes\Test;
 
 class CheckableTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_creates_checkbox_field(): void
     {
         $defaultOptions = [
@@ -43,7 +44,7 @@ class CheckableTypeTest extends FormBuilderTestCase
         $this->assertEquals($expectedOptions, $checkable->getOptions());
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_radio_field(): void
     {
         $defaultOptions = [
@@ -82,7 +83,7 @@ class CheckableTypeTest extends FormBuilderTestCase
         $this->assertEquals($expectedOptions, $checkable->getOptions());
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_values(): void
     {
         $expectedValue = 2;
@@ -96,7 +97,7 @@ class CheckableTypeTest extends FormBuilderTestCase
         $this->assertSame($expectedValue, $checkable->getOption('value'));
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_checked(): void
     {
         $options = [

--- a/tests/Fields/ChildFormTypeTest.php
+++ b/tests/Fields/ChildFormTypeTest.php
@@ -4,10 +4,11 @@ use Kris\LaravelFormBuilder\Fields\ChoiceType;
 use Kris\LaravelFormBuilder\Fields\CollectionType;
 use Kris\LaravelFormBuilder\Fields\SelectType;
 use Kris\LaravelFormBuilder\Form;
+use PHPUnit\Framework\Attributes\Test;
 
 class ChildFormTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_implicitly_inherits_language_name()
     {
         $plainParent = $this->formBuilder->plain(['language_name' => 'test_name']);
@@ -19,7 +20,7 @@ class ChildFormTypeTest extends FormBuilderTestCase
         $this->assertEquals('test_name', $plainChild->getLanguageName());
     }
 
-    /** @test */
+    #[Test]
     public function it_implicitly_inherits_translation_template()
     {
         $plainParent = $this->formBuilder->plain(['translation_template' => 'form.{name}.{type}']);
@@ -31,7 +32,7 @@ class ChildFormTypeTest extends FormBuilderTestCase
         $this->assertEquals('form.{name}.{type}', $plainChild->getTranslationTemplate());
     }
 
-    /** @test */
+    #[Test]
     public function it_does_not_overwrite_language_name()
     {
         $plainParent = $this->formBuilder->plain(['language_name' => 'test_name']);
@@ -43,7 +44,7 @@ class ChildFormTypeTest extends FormBuilderTestCase
         $this->assertEquals('test_name', $plainParent->getLanguageName());
     }
 
-    /** @test */
+    #[Test]
     public function it_does_not_overwrite_translation_template()
     {
         $plainParent = $this->formBuilder->plain(['translation_template' => 'test.{name}']);

--- a/tests/Fields/ChoiceTypeTest.php
+++ b/tests/Fields/ChoiceTypeTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\ChoiceType;
+use PHPUnit\Framework\Attributes\Test;
 
 class ChoiceTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_creates_choice_as_select()
     {
         $options = [
@@ -22,7 +23,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         $this->assertEquals('yes', $choice->getOption('selected'));
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_choice_as_checkbox_list()
     {
         $options = [
@@ -44,7 +45,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         $this->assertContainsOnlyInstancesOf('Kris\LaravelFormBuilder\Fields\CheckableType', $choice->getChildren());
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_choice_as_radio_buttons()
     {
         $options = [
@@ -70,7 +71,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         $this->assertContainsOnlyInstancesOf('Kris\LaravelFormBuilder\Fields\CheckableType', $choice->getChildren());
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_proper_name_for_multiple()
     {
         $this->plainForm->add('users', 'select', [
@@ -85,7 +86,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         $this->assertEquals('users[]', $this->plainForm->users->getName());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_override_choices()
     {
         $options = [
@@ -107,7 +108,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         $this->assertEquals('test', $choice->getOption('selected'));
     }
 
-    /** @test */
+    #[Test]
     public function it_disables_select()
     {
         $options = [
@@ -135,7 +136,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_disables_checkbox_list()
     {
         $options = [
@@ -166,7 +167,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         }
     }
     
-    /** @test */
+    #[Test]
     public function it_disables_radios_list()
     {
         $options = [
@@ -196,7 +197,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         }
     }
     
-    /** @test */
+    #[Test]
     public function it_enables_select()
     {
         $options = [
@@ -225,7 +226,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_enables_checkbox_list()
     {
         $options = [
@@ -257,7 +258,7 @@ class ChoiceTypeTest extends FormBuilderTestCase
         }
     }
     
-    /** @test */
+    #[Test]
     public function it_enables_radios_list()
     {
         $options = [

--- a/tests/Fields/CollectionTypeTest.php
+++ b/tests/Fields/CollectionTypeTest.php
@@ -8,12 +8,13 @@ namespace {
     use Kris\LaravelFormBuilder\Form;
     use Illuminate\Foundation\Testing\Concerns\InteractsWithSession;
     use Illuminate\Database\Eloquent\Model;
+    use PHPUnit\Framework\Attributes\Test;
 
     class CollectionTypeTest extends FormBuilderTestCase
     {
         use InteractsWithSession;
 
-        /** @test */
+        #[Test]
         public function it_creates_collection()
         {
             $options = [
@@ -31,7 +32,7 @@ namespace {
             $this->assertInstanceOf('Kris\LaravelFormBuilder\Fields\SelectType', $emailsCollection->prototype());
         }
 
-        /** @test */
+        #[Test]
         public function it_creates_collection_with_empty_row()
         {
             $options = [
@@ -43,7 +44,7 @@ namespace {
             $this->assertEquals(1, count($emailsCollection->getChildren()));
         }
 
-        /** @test */
+        #[Test]
         public function it_creates_collection_without_empty_row()
         {
             $options = [
@@ -56,7 +57,7 @@ namespace {
             $this->assertEquals(0, count($emailsCollection->getChildren()));
         }
 
-        /** @test */
+        #[Test]
         public function it_uses_old_input_if_available()
         {
             $options = [
@@ -78,7 +79,7 @@ namespace {
             $this->assertInstanceOf('Kris\LaravelFormBuilder\Fields\SelectType', $emailsCollection->prototype());
         }
 
-        /** @test */
+        #[Test]
         public function it_creates_collection_with_child_form()
         {
             $form = clone $this->plainForm;
@@ -109,7 +110,7 @@ namespace {
             $this->assertEquals(2, count($childFormCollection->getChildren()));
         }
 
-        /** @test */
+        #[Test]
         public function it_creates_collection_with_child_form_with_correct_model()
         {
             $model = new DummyEloquentModel();
@@ -139,7 +140,7 @@ namespace {
             }
         }
 
-        /** @test */
+        #[Test]
         public function it_creates_collection_with_child_form_with_correct_model_properties()
         {
             $items = new \Illuminate\Support\Collection([
@@ -158,9 +159,7 @@ namespace {
             $this->assertEquals($items, $collectionValue);
         }
 
-        /**
-         * @test
-         */
+        #[Test]
         public function it_throws_exception_when_requesting_prototype_while_it_is_disabled()
         {
             $this->expectException(\Exception::class);
@@ -177,9 +176,7 @@ namespace {
             $childFormCollection->prototype();
         }
 
-        /**
-         * @test
-         */
+        #[Test]
         public function it_throws_exception_when_creating_nonexisting_type()
         {
             $this->expectException(\Exception::class);
@@ -191,9 +188,7 @@ namespace {
             $childFormCollection = new CollectionType('emails', 'collection', $this->plainForm, $options);
         }
 
-        /**
-         * @test
-         */
+        #[Test]
         public function it_throws_exception_when_data_is_not_iterable()
         {
             $this->expectException(\Throwable::class);
@@ -207,9 +202,7 @@ namespace {
             $childFormCollection = new CollectionType('emails', 'collection', $this->plainForm, $options);
         }
 
-        /**
-         * @test
-         */
+        #[Test]
         public function it_sets_up_prototype_with_empty_values()
         {
             $form = $this->formBuilder->plain([
@@ -230,7 +223,7 @@ namespace {
             );
         }
 
-        /** @test */
+        #[Test]
         public function it_uses_empty_model_for_empty_row_child_form()
         {
             $items = new \Illuminate\Support\Collection([]);
@@ -247,7 +240,7 @@ namespace {
             $this->assertInstanceOf(DummyEloquentModel2::class, $itemsChildren[0]->getForm()->getModel());
         }
 
-        /** @test */
+        #[Test]
         public function it_uses_empty_model_for_proto_child_forms()
         {
             $items = new \Illuminate\Support\Collection([
@@ -267,7 +260,7 @@ namespace {
             $this->assertTrue($protoModel->_custom);
         }
 
-        /** @test */
+        #[Test]
         public function it_uses_empty_model_for_new_collection_children_after_validation_error()
         {
             $items = new \Illuminate\Support\Collection([
@@ -297,7 +290,7 @@ namespace {
             }
         }
 
-        /** @test */
+        #[Test]
         public function it_disables()
         {
             $options = [
@@ -321,7 +314,7 @@ namespace {
             }
         }
         
-        /** @test */
+        #[Test]
         public function it_enables()
         {
             $options = [

--- a/tests/Fields/EntityTypeTest.php
+++ b/tests/Fields/EntityTypeTest.php
@@ -2,10 +2,11 @@
 
 use Kris\LaravelFormBuilder\Fields\EntityType;
 use Kris\LaravelFormBuilder\Form;
+use PHPUnit\Framework\Attributes\Test;
 
 class EntityTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_uses_default_choices_for_entity_type()
     {
         $choices = ['yes' => 'Yes', 'no' => 'No'];
@@ -23,7 +24,7 @@ class EntityTypeTest extends FormBuilderTestCase
         $this->assertEquals('yes', $choice->getOption('selected'));
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_passed_class_model_to_fetch_all()
     {
         $mdl = new DummyModel();
@@ -43,9 +44,7 @@ class EntityTypeTest extends FormBuilderTestCase
         $this->assertEquals($expected, $choice->getOption('choices'));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_an_exception_if_model_class_not_provided()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -55,7 +54,7 @@ class EntityTypeTest extends FormBuilderTestCase
         $choice = new EntityType('entity_choice', 'entity', $this->plainForm, $options);
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_query_builder_to_filter_choices()
     {
         $mdl = new DummyModel();
@@ -80,7 +79,7 @@ class EntityTypeTest extends FormBuilderTestCase
         $this->assertEquals($expected, $choice->getOption('choices'));
     }
 
-    /** @test */
+    #[Test]
     public function options_are_passed_to_the_children()
     {
         $mdl = new DummyModel();
@@ -101,7 +100,7 @@ class EntityTypeTest extends FormBuilderTestCase
             $this->assertXmlStringEqualsXmlString(trim($field), $expectedField);
         }
 
-    /** @test */
+    #[Test]
     public function it_disables()
     {
         $choices = ['yes' => 'Yes', 'no' => 'No'];
@@ -129,7 +128,7 @@ class EntityTypeTest extends FormBuilderTestCase
         }
     }
     
-    /** @test */
+    #[Test]
     public function it_enables()
     {
         $choices = ['yes' => 'Yes', 'no' => 'No'];

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -413,7 +413,6 @@ class FormFieldTest extends FormBuilderTestCase
 
         $reflection = new \ReflectionClass($plainForm);
         $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
 
         $this->assertTrue($method->invokeArgs($plainForm, []));
         $this->assertFalse($method->invokeArgs($modifiedForm, []));
@@ -430,8 +429,6 @@ class FormFieldTest extends FormBuilderTestCase
 
         $reflection = new \ReflectionClass($customPlainForm);
         $method = $reflection->getMethod($methodName);
-        $method->setAccessible(true);
-
 
         $this->assertTrue($method->invokeArgs($customPlainForm, []));
     }

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -4,10 +4,11 @@ use Illuminate\Http\Request;
 use Kris\LaravelFormBuilder\Fields\CheckableType;
 use Kris\LaravelFormBuilder\Fields\InputType;
 use Kris\LaravelFormBuilder\FormHelper;
+use PHPUnit\Framework\Attributes\Test;
 
 class FormFieldTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_use_set_rendered()
     {
         $field = new InputType('name', 'text', $this->plainForm);
@@ -19,7 +20,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertTrue($field->isRendered());
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_the_template_prefix()
     {
         $viewStub = $this->getViewFactoryMock();
@@ -46,7 +47,7 @@ class FormFieldTest extends FormBuilderTestCase
         $field->render();
     }
 
-    /** @test */
+    #[Test]
     public function it_hides_the_label_with_label_show_property()
     {
         $options = [
@@ -62,7 +63,7 @@ class FormFieldTest extends FormBuilderTestCase
     }
 
 
-    /** @test */
+    #[Test]
     public function it_sets_required_as_class_on_the_label_and_attribute_on_the_field_when_setting_required_explicitly()
     {
         $options = [
@@ -76,7 +77,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertArrayHasKey('required', $hidden->getOption('attr'));
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_required_as_class_on_the_label_and_attribute_on_the_field_when_setting_required_via_a_rule()
     {
         $options = [
@@ -90,7 +91,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertArrayHasKey('required', $hidden->getOption('attr'));
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_the_required_class_to_the_label_when_client_side_validation_is_disabled()
     {
         $options = [
@@ -106,7 +107,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertArrayNotHasKey('required', $hidden->getOption('attr'));
     }
 
-    /** @test */
+    #[Test]
     public function it_appends_to_the_class_attribute_of_the_field()
     {
         $options = [
@@ -127,7 +128,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertStringNotContainsString('class_append', $renderResult);
     }
 
-    /** @test */
+    #[Test]
     public function it_appends_to_the_class_attribute_of_a_custom_classes_checkbox_field()
     {
         $options = [
@@ -147,7 +148,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertStringNotContainsString($defaultClasses, $text->getOption('attr.class'));
     }
 
-    /** @test */
+    #[Test]
     public function it_appends_to_the_class_attribute_of_the_label()
     {
         $options = [
@@ -168,7 +169,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertStringNotContainsString('class_append', $renderResult);
     }
 
-    /** @test */
+    #[Test]
     public function it_appends_to_the_class_attribute_of_the_wrapper()
     {
         $options = [
@@ -189,7 +190,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertStringNotContainsString('class_append', $renderResult);
     }
 
-    /** @test */
+    #[Test]
     public function it_appends_rules_properly()
     {
 
@@ -223,7 +224,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertEquals($expected, $field->getOption('rules'));
     }
 
-    /** @test */
+    #[Test]
     public function it_translates_the_label_if_translation_exists()
     {
         // We use build in validation translations prefix for easier testing
@@ -236,7 +237,7 @@ class FormFieldTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_translates_the_label_using_translation_templates()
     {
         // We use build in validation translations prefix for easier testing
@@ -249,7 +250,7 @@ class FormFieldTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function provided_label_from_option_overrides_translated_one()
     {
         // We use build in validation translations prefix for easier testing
@@ -264,7 +265,7 @@ class FormFieldTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_fallbacks_to_simple_format_if_no_translation_and_custom_label_provided()
     {
         // We use build in validation translations prefix for easier testing
@@ -298,7 +299,7 @@ class FormFieldTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_initialize_all_defined_field_filters()
     {
         $customPlainForm = $this->formBuilder->plain();
@@ -315,7 +316,7 @@ class FormFieldTest extends FormBuilderTestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_enables_overriding_existing_filters()
     {
         $customPlainForm = $this->formBuilder->plain();
@@ -329,7 +330,7 @@ class FormFieldTest extends FormBuilderTestCase
         );
     }
 
-    /** @test  */
+    #[Test]
     public function it_throws_an_exception_if_filters_override_is_false_but_passed_already_binded_filter()
     {
         $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\FilterAlreadyBindedException::class);
@@ -343,7 +344,7 @@ class FormFieldTest extends FormBuilderTestCase
         $testField->addFilter('Trim');
     }
 
-    /** @test */
+    #[Test]
     public function it_overrides_already_existing_filter()
     {
         $customPlainForm = $this->formBuilder->plain();
@@ -359,7 +360,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertArrayHasKey($filter, $testField->getFilters());
     }
 
-    /** @test */
+    #[Test]
     public function it_removes_binded_filter()
     {
         $customPlainForm = $this->formBuilder->plain();
@@ -373,7 +374,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertArrayHasKey('Uppercase', $testField->getFilters());
     }
 
-    /** @test */
+    #[Test]
     public function it_removes_multiple_filters()
     {
         $customPlainForm = $this->formBuilder->plain();
@@ -387,7 +388,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertEmpty($testField->getFilters());
     }
 
-    /** @test */
+    #[Test]
     public function it_clears_all_filters()
     {
         $customPlainForm = $this->formBuilder->plain();
@@ -400,7 +401,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertEmpty($testField->getFilters());
     }
 
-    /** @test */
+    #[Test]
     public function it_is_plain()
     {
         $methodName = 'isPlain';
@@ -416,7 +417,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertFalse($method->invokeArgs($modifiedForm, []));
     }
 
-    /** @test */
+    #[Test]
     public function it_custom_plain_form_is_plain()
     {
         $methodName = 'isPlain';
@@ -433,7 +434,7 @@ class FormFieldTest extends FormBuilderTestCase
         $this->assertTrue($method->invokeArgs($customPlainForm, []));
     }
 
-    /** @test */
+    #[Test]
     public function label_template()
     {
         $fieldsOptions = [

--- a/tests/Fields/FormFieldTest.php
+++ b/tests/Fields/FormFieldTest.php
@@ -4,6 +4,7 @@ use Illuminate\Http\Request;
 use Kris\LaravelFormBuilder\Fields\CheckableType;
 use Kris\LaravelFormBuilder\Fields\InputType;
 use Kris\LaravelFormBuilder\FormHelper;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 
 class FormFieldTest extends FormBuilderTestCase
@@ -21,6 +22,7 @@ class FormFieldTest extends FormBuilderTestCase
     }
 
     #[Test]
+    #[AllowMockObjectsWithoutExpectations]
     public function it_uses_the_template_prefix()
     {
         $viewStub = $this->getViewFactoryMock();

--- a/tests/Fields/InputTypeTest.php
+++ b/tests/Fields/InputTypeTest.php
@@ -3,10 +3,11 @@
 use Kris\LaravelFormBuilder\Fields\ButtonType;
 use Kris\LaravelFormBuilder\Fields\InputType;
 use Kris\LaravelFormBuilder\Form;
+use PHPUnit\Framework\Attributes\Test;
 
 class InputTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_prevents_rendering_label_for_hidden_field()
     {
         $options = [
@@ -36,7 +37,7 @@ class InputTypeTest extends FormBuilderTestCase
     }
 
 
-    /** @test */
+    #[Test]
     public function it_handles_default_values()
     {
         $options = [
@@ -48,7 +49,7 @@ class InputTypeTest extends FormBuilderTestCase
         $this->assertEquals(100, $input->getOption('value'));
     }
 
-    /** @test */
+    #[Test]
     public function model_value_overrides_default_value()
     {
         $options = [
@@ -60,7 +61,7 @@ class InputTypeTest extends FormBuilderTestCase
         $this->assertEquals(5, $input->getValue());
     }
 
-    /** @test */
+    #[Test]
     public function explicit_value_overrides_default_values()
     {
         $options = [

--- a/tests/Fields/RepeatedTypeTest.php
+++ b/tests/Fields/RepeatedTypeTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\RepeatedType;
+use PHPUnit\Framework\Attributes\Test;
 
 class RepeatedTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_creates_repeated_as_two_inputs()
     {
         $repeatedForm = $this->formBuilder->plain();
@@ -20,7 +21,7 @@ class RepeatedTypeTest extends FormBuilderTestCase
         $this->assertNull($repeated->third);
     }
 
-    /** @test */
+    #[Test]
     public function it_checks_if_field_rendered_by_children()
     {
         $repeated = new RepeatedType('password', 'repeated', $this->plainForm, [
@@ -36,7 +37,7 @@ class RepeatedTypeTest extends FormBuilderTestCase
         $this->assertTrue($this->plainForm->getFormOption('files'));
     }
 
-    /** @test */
+    #[Test]
     public function handles_validation_rules_properly()
     {
         // has no other rules

--- a/tests/Fields/SelectTypeTest.php
+++ b/tests/Fields/SelectTypeTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\SelectType;
+use PHPUnit\Framework\Attributes\Test;
 
 class SelectTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_creates_select_field(): void
     {
         $choices = [

--- a/tests/Fields/StaticTypeTest.php
+++ b/tests/Fields/StaticTypeTest.php
@@ -2,11 +2,12 @@
 
 use Kris\LaravelFormBuilder\Fields\StaticType;
 use Kris\LaravelFormBuilder\Form;
+use PHPUnit\Framework\Attributes\Test;
 
 class StaticTypeTest extends FormBuilderTestCase
 {
 
-    /** @test */
+    #[Test]
     public function it_creates_static_field()
     {
         $options = [

--- a/tests/Fields/TextareaTypeTest.php
+++ b/tests/Fields/TextareaTypeTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\TextareaType;
+use PHPUnit\Framework\Attributes\Test;
 
 class TextareaTypeTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_creates_txetarea_field(): void
     {
         $options = [
@@ -35,7 +36,7 @@ class TextareaTypeTest extends FormBuilderTestCase
         $this->assertEquals($expectedOptions, $textarea->getOptions());
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_default_values(): void
     {
         $options = [
@@ -47,7 +48,7 @@ class TextareaTypeTest extends FormBuilderTestCase
         $this->assertEquals('default text', $textarea->getOption('value'));
     }
 
-    /** @test */
+    #[Test]
     public function model_value_overrides_default_value(): void
     {
         $options = [
@@ -59,7 +60,7 @@ class TextareaTypeTest extends FormBuilderTestCase
         $this->assertEquals( 'override text', $textarea->getValue());
     }
 
-    /** @test */
+    #[Test]
     public function explicit_value_overrides_default_values(): void
     {
         $options = [

--- a/tests/Filters/FilterResolverTest.php
+++ b/tests/Filters/FilterResolverTest.php
@@ -1,10 +1,11 @@
 <?php
 
 use \Kris\LaravelFormBuilder\Filters\Collection\Trim;
+use PHPUnit\Framework\Attributes\Test;
 
 class FilterResolverTest extends FormBuilderTestCase
 {
-    /** @test */
+    #[Test]
     public function it_resolve_alias_based_filter()
     {
         $expected = \Kris\LaravelFormBuilder\Filters\FilterInterface::class;
@@ -14,7 +15,7 @@ class FilterResolverTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_resolve_object_based_filter()
     {
         $expected  = \Kris\LaravelFormBuilder\Filters\FilterInterface::class;
@@ -32,9 +33,7 @@ class FilterResolverTest extends FormBuilderTestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_an_exception_if_object_is_not_instance_of_filterinterface()
     {
         $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\InvalidInstanceException::class);
@@ -44,9 +43,7 @@ class FilterResolverTest extends FormBuilderTestCase
         $resolver::instance($invalidFilterObj);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_an_exception_if_filter_cant_be_resolved()
     {
         $this->expectException(\Kris\LaravelFormBuilder\Filters\Exception\UnableToResolveFilterException::class);

--- a/tests/FormBuilderServiceProviderTest.php
+++ b/tests/FormBuilderServiceProviderTest.php
@@ -4,6 +4,7 @@ namespace {
 
     use App\FormBuilderStuff\MyFormBuilder;
     use App\FormBuilderStuff\SomeService;
+    use PHPUnit\Framework\Attributes\Test;
 
     class FormBuilderServiceProviderTest extends FormBuilderTestCase
     {
@@ -15,7 +16,7 @@ namespace {
             $app['config']->set('laravel-form-builder.form_builder_class', MyFormBuilder::class);
         }
 
-        /** @test */
+        #[Test]
         public function it_dependency_injects()
         {
             // The right form builder class is used for the container form builder.

--- a/tests/FormBuilderTest.php
+++ b/tests/FormBuilderTest.php
@@ -7,11 +7,12 @@ namespace {
     use Kris\LaravelFormBuilder\Form;
     use Kris\LaravelFormBuilder\FormBuilder;
     use Kris\LaravelFormBuilder\FormHelper;
+    use PHPUnit\Framework\Attributes\Test;
 
     class FormBuilderTest extends FormBuilderTestCase
     {
 
-        /** @test */
+        #[Test]
         public function it_creates_plain_form_and_sets_options_on_it()
         {
             $options = [
@@ -28,7 +29,7 @@ namespace {
             $this->assertNull($plainForm->buildForm());
         }
 
-        /** @test */
+        #[Test]
         public function it_creates_form_with_array_and_compares_it_with_created_form_by_class()
         {
             $form = $this->formBuilder->create(CustomDummyForm::class);
@@ -47,7 +48,7 @@ namespace {
             $this->assertEquals($form->getField('body')->getType(), $arrayForm->getField('body')->getType());
         }
 
-        /** @test */
+        #[Test]
         public function it_creates_custom_form_and_sets_options_on_it()
         {
             $options = [
@@ -67,7 +68,7 @@ namespace {
             $this->assertArrayHasKey('body', $customForm->getFields());
         }
 
-        /** @test */
+        #[Test]
         public function it_receives_creation_events()
         {
             $events = [];
@@ -102,9 +103,7 @@ namespace {
             );
         }
 
-        /**
-         * @test
-         */
+        #[Test]
         public function it_throws_exception_if_child_form_is_not_valid_class()
         {
             $this->expectException(\InvalidArgumentException::class);
@@ -113,9 +112,7 @@ namespace {
             ]);
         }
 
-        /**
-         * @test
-         */
+        #[Test]
         public function it_throws_exception_if_child_form_class_is_not_passed()
         {
             $this->expectException(\InvalidArgumentException::class);
@@ -125,9 +122,7 @@ namespace {
             ]);
         }
 
-        /**
-         * @test
-         */
+        #[Test]
         public function it_throws_exception_if_child_form_class_is_not_valid_format()
         {
             $this->expectException(\InvalidArgumentException::class);
@@ -137,7 +132,7 @@ namespace {
             ]);
         }
 
-        /** @test */
+        #[Test]
         public function it_can_set_form_helper_once_and_call_build_form()
         {
             $form = $this->formBuilder->create('CustomDummyForm');
@@ -148,7 +143,7 @@ namespace {
             $this->assertArrayHasKey('body', $form->getFields());
         }
 
-        /** @test */
+        #[Test]
         public function it_appends_default_namespace_from_config_on_building()
         {
             $form =  new LaravelFormBuilderTest\Forms\NamespacedDummyForm();

--- a/tests/FormBuilderTestCase.php
+++ b/tests/FormBuilderTestCase.php
@@ -2,6 +2,8 @@
 
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Contracts\Validation\Factory;
+use Illuminate\Contracts\View\Factory as ViewFactoryContract;
+use Illuminate\Contracts\View\View as ViewContract;
 use Illuminate\Database\Eloquent\Model;
 use Kris\LaravelFormBuilder\Filters\FilterResolver;
 use Kris\LaravelFormBuilder\Form;
@@ -214,6 +216,8 @@ abstract class FormBuilderTestCase extends TestCase {
 
     public function tearDown(): void
     {
+        parent::tearDown();
+
         $this->view = null;
         $this->request = null;
         $this->container = null;
@@ -276,13 +280,12 @@ abstract class FormBuilderTestCase extends TestCase {
 
     protected function getViewFactoryMock()
     {
-        $mock = $this->getMockBuilder('Illuminate\View\Factory')
-            ->onlyMethods(['make'])
-            ->addMethods(['with', 'render'])
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mock->method('make')->willReturn($mock);
-        $mock->method('with')->willReturn($mock);
-        return $mock;
+        $view = $this->createMock(ViewContract::class);
+        $view->method('with')->willReturnSelf();
+
+        $factory = $this->createMock(ViewFactoryContract::class);
+        $factory->method('make')->willReturn($view);
+
+        return $factory;
     }
 }

--- a/tests/FormHelperTest.php
+++ b/tests/FormHelperTest.php
@@ -2,17 +2,18 @@
 
 use Kris\LaravelFormBuilder\FormHelper;
 use Illuminate\Support\Collection;
+use PHPUnit\Framework\Attributes\Test;
 
 class FormHelperTest extends FormBuilderTestCase
 {
 
-    /** @test */
+    #[Test]
     public function it_sets_constructor_dependencies_to_properties()
     {
         $this->assertEquals($this->view, $this->formHelper->getView());
     }
 
-    /** @test */
+    #[Test]
     public function it_merges_options_properly()
     {
         $initial = [
@@ -37,7 +38,7 @@ class FormHelperTest extends FormBuilderTestCase
         $this->assertEquals($expected, $mergedOptions);
     }
 
-    /** @test */
+    #[Test]
     public function it_gets_proper_class_for_specific_field_type()
     {
         $input = $this->formHelper->getFieldType('text');
@@ -71,9 +72,7 @@ class FormHelperTest extends FormBuilderTestCase
         $this->assertEquals('Kris\\LaravelFormBuilder\\Fields\\InputType', $className);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_InvalidArgumentException_for_non_existing_field_type()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -81,7 +80,7 @@ class FormHelperTest extends FormBuilderTestCase
         $this->formHelper->getFieldType('nonexisting');
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_html_attributes_from_array_of_options()
     {
         $options = ['class' => 'form-control', 'data-id' => 1, 'id' => 'post'];
@@ -94,7 +93,7 @@ class FormHelperTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_load_custom_field_types_from_config()
     {
         $config = $this->config;
@@ -109,7 +108,7 @@ class FormHelperTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_formats_the_label()
     {
         $this->assertEquals(
@@ -125,7 +124,7 @@ class FormHelperTest extends FormBuilderTestCase
         $this->assertNull($this->formHelper->formatLabel(false));
     }
 
-    /** @test */
+    #[Test]
     public function it_converts_model_to_array()
     {
         $data = ['m' => 'male', 'f' => 'female'];
@@ -141,9 +140,7 @@ class FormHelperTest extends FormBuilderTestCase
         $this->assertNull($this->formHelper->convertModelToArray([]));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_InvalidArgumentException_for_empty_field_name()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -151,9 +148,7 @@ class FormHelperTest extends FormBuilderTestCase
         $this->formHelper->checkFieldName('', get_class($this));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_InvalidArgumentException_for_reserved_field_names()
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -7,6 +7,7 @@ use Kris\LaravelFormBuilder\Fields\InputType;
 use Kris\LaravelFormBuilder\Form;
 use Kris\LaravelFormBuilder\FormHelper;
 use Kris\LaravelFormBuilder\FormBuilder;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 
 class FormTest extends FormBuilderTestCase
@@ -1094,6 +1095,7 @@ class FormTest extends FormBuilderTestCase
     }
 
     #[Test]
+    #[AllowMockObjectsWithoutExpectations]
     public function it_uses_the_template_prefix()
     {
         $viewStub = $this->getViewFactoryMock();

--- a/tests/FormTest.php
+++ b/tests/FormTest.php
@@ -7,11 +7,12 @@ use Kris\LaravelFormBuilder\Fields\InputType;
 use Kris\LaravelFormBuilder\Form;
 use Kris\LaravelFormBuilder\FormHelper;
 use Kris\LaravelFormBuilder\FormBuilder;
+use PHPUnit\Framework\Attributes\Test;
 
 class FormTest extends FormBuilderTestCase
 {
 
-    /** @test */
+    #[Test]
     public function it_adds_fields()
     {
         $this->plainForm
@@ -49,7 +50,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_passes_validation()
     {
         $this->plainForm
@@ -73,7 +74,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_fails_validation()
     {
         $this->plainForm
@@ -97,7 +98,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals($errors, $this->plainForm->getErrors());
     }
 
-    /** @test */
+    #[Test]
     public function it_alters_validity_and_adds_messages()
     {
         $customForm = $this->formBuilder->create('CustomNesterDummyForm');
@@ -119,7 +120,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_can_automatically_redirect_back_when_failing_verification()
     {
         $this->plainForm
@@ -157,7 +158,7 @@ class FormTest extends FormBuilderTestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_can_automatically_redirect_to_a_specified_destination_when_failing_verification()
     {
         $this->plainForm
@@ -195,7 +196,7 @@ class FormTest extends FormBuilderTestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_overrides_default_rules_and_messages()
     {
         $this->plainForm
@@ -241,7 +242,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals($errors, $this->plainForm->getErrors());
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_error_messages_from_fields()
     {
         $childForm = $this->formBuilder->plain();
@@ -275,9 +276,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals($errors, $this->plainForm->getErrors());
     }
 
-    /**
-     * @test
-     * */
+    #[Test]
     public function it_throws_exception_when_errors_requested_from_non_validated_form()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -294,7 +293,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->getErrors();
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_field_values()
     {
         $this->plainForm
@@ -346,7 +345,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_altered_field_values()
     {
         $this->request['name'] = 'lower case';
@@ -372,7 +371,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_after_some_field()
     {
         $this->plainForm
@@ -408,7 +407,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_before_some_field()
     {
         $this->plainForm
@@ -445,7 +444,7 @@ class FormTest extends FormBuilderTestCase
     }
 
 
-    /** @test */
+    #[Test]
     public function it_can_remove_existing_fields_from_form_object()
     {
         $this->plainForm
@@ -465,7 +464,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertFalse($this->plainForm->has('description'));
     }
 
-    /** @test */
+    #[Test]
     public function it_can_take_and_replace_existing_fields()
     {
         $this->plainForm
@@ -483,7 +482,7 @@ class FormTest extends FormBuilderTestCase
     }
 
 
-    /** @test */
+    #[Test]
     public function it_can_modify_existing_fields()
     {
         $this->plainForm
@@ -534,9 +533,7 @@ class FormTest extends FormBuilderTestCase
 
     }
 
-    /**
-     * @test
-     */
+    #[Test]
      public function it_throws_exception_when_rendering_until_nonexisting_field()
      {
          $this->expectException(\InvalidArgumentException::class);
@@ -549,9 +546,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->renderUntil('nonexisting');
      }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_prevents_adding_fields_with_same_name()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -559,9 +554,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->add('name', 'text')->add('name', 'textarea');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_if_field_name_is_reserved()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -569,7 +562,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->add('save', 'submit');
     }
 
-    /** @test */
+    #[Test]
     public function it_throws_InvalidArgumentException_on_non_existing_property()
     {
         $exceptionThrown = false;
@@ -598,7 +591,7 @@ class FormTest extends FormBuilderTestCase
         $this->fail('Exception was not thrown for non existing field.');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_form_options_with_array_of_options()
     {
         $options = [
@@ -623,7 +616,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_can_set_form_options_with_setters()
     {
         $this->plainForm->setMethod('DELETE');
@@ -644,7 +637,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('test_name', $this->plainForm->getName());
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_file_option_to_true_if_file_type_added()
     {
         $this->plainForm->add('upload_file', 'file');
@@ -652,7 +645,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertTrue($this->plainForm->getFormOption('files'));
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_the_form()
     {
         $formOptions = [
@@ -667,7 +660,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertNotThrown();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_rest_of_the_form()
     {
         $options = [
@@ -694,7 +687,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertNotThrown();
     }
 
-    /** @test */
+    #[Test]
     public function it_renders_rest_of_the_form_until_specified_field()
     {
         $options = [
@@ -721,7 +714,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals($this->plainForm->address->isRendered(), false);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_add_child_form_as_field()
     {
         $model = ['song' => ['body' => 'test body'], 'title' => 'main title'];
@@ -788,7 +781,7 @@ class FormTest extends FormBuilderTestCase
         $this->fail('No exception on bad method call on child form.');
     }
 
-    /** @test */
+    #[Test]
     public function it_can_use_model_property_to_set_value()
     {
         $form = $this->formBuilder->plain([
@@ -802,7 +795,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals($form->alias_accessor->getValue(), $this->model->accessor);
     }
 
-    /** @test */
+    #[Test]
     public function it_sets_entity_field_value_to_the_entity_model_value()
     {
         $dummyModel = new DummyModel();
@@ -822,7 +815,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals($form->dummy_model_id->getValue(), $this->model->dummy_model_id);
     }
 
-    /** @test */
+    #[Test]
     public function it_reads_configuration_properly()
     {
         $config = $this->config;
@@ -848,7 +841,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertMatchesRegularExpression('/input.*class="my-text-class"/', $overridenView);
     }
 
-    /** @test */
+    #[Test]
     public function it_works_when_setModel_method_is_called()
     {
         $customForm = $this->formBuilder->create('CustomDummyForm')->setModel([
@@ -860,7 +853,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('john doe', $customForm->title->getValue());
     }
 
-    /** @test */
+    #[Test]
     public function it_removes_children_from_parent_type_fields()
     {
         $model = ['song' => ['title' => 'test song title', 'body' => 'test body'], 'title' => 'main title'];
@@ -894,7 +887,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('test body', $form->song->body->getValue());
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_named_form()
     {
         $model = new \Illuminate\Support\Collection([
@@ -918,7 +911,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals($expectModel, $this->plainForm->getModel());
     }
 
-    /** @test */
+    #[Test]
     public function it_has_html_valid_element_names()
     {
         $this->plainForm
@@ -931,7 +924,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('child[form][name][text]', $this->plainForm->getField('child[form]')->getField('name[text]')->getName());
     }
 
-    /** @test */
+    #[Test]
     public function it_adds_custom_type()
     {
         $this->plainForm->addCustomField('datetime', 'Some\\Namespace\\DatetimeType');
@@ -941,9 +934,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('Some\\Namespace\\DatetimeType', $fieldType);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_adding_field_with_invalid_name()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -951,9 +942,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->add('', 'text');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_throws_exception_when_adding_field_with_invalid_type()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -961,9 +950,7 @@ class FormTest extends FormBuilderTestCase
         $this->plainForm->add('name', '');
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_prevents_adding_duplicate_custom_type()
     {
         $this->expectException(\InvalidArgumentException::class);
@@ -974,7 +961,7 @@ class FormTest extends FormBuilderTestCase
     }
 
 
-    /** @test */
+    #[Test]
     public function it_can_compose_another_forms_fields_into_itself()
     {
         $form = $this->formBuilder->plain();
@@ -993,7 +980,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('title', $form->title->getRealName());
     }
 
-    /** @test */
+    #[Test]
     public function it_disables_all_fields_in_form()
     {
         $form = $this->formBuilder->plain();
@@ -1011,7 +998,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('disabled', $form->name->getOption('attr.disabled'));
     }
 
-    /** @test */
+    #[Test]
     public function it_enables_all_fields_in_form()
     {
         $form = $this->formBuilder->plain();
@@ -1032,7 +1019,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertNull($form->name->getOption('attr.disabled'));
     }
 
-    /** @test */
+    #[Test]
     public function it_allows_disabling_showing_form_errors()
     {
         $this->plainForm->add('child_form', 'form', ['class'=> 'CustomDummyForm']);
@@ -1044,7 +1031,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertFalse($this->plainForm->getField('child_form')->haveErrorsEnabled());
     }
 
-    /** @test */
+    #[Test]
     public function it_allows_disabling_client_validation()
     {
         $this->plainForm->add('child_form', 'form', ['class'=> 'CustomDummyForm']);
@@ -1058,7 +1045,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertFalse($this->plainForm->getField('child_form')->clientValidationEnabled());
     }
 
-    /** @test */
+    #[Test]
     public function it_receives_validation_events()
     {
         $events = [];
@@ -1086,7 +1073,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_has_a_template_prefix()
     {
         $form = $this->formBuilder->plain();
@@ -1097,7 +1084,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertNull($form->getFormOption('template_prefix'));
     }
 
-    /** @test */
+    #[Test]
     public function it_stores_a_template_prefix()
     {
         $form = $this->formBuilder->plain();
@@ -1106,7 +1093,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('test_prefix::', $form->getTemplatePrefix());
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_the_template_prefix()
     {
         $viewStub = $this->getViewFactoryMock();
@@ -1128,7 +1115,7 @@ class FormTest extends FormBuilderTestCase
         $form->renderForm();
     }
 
-    /** @test */
+    #[Test]
     public function it_locks_filtering()
     {
         $customPlainForm = $this->formBuilder->plain();
@@ -1139,7 +1126,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_returns_binded_field_filters()
     {
         $customPlainForm = $this->formBuilder->plain();
@@ -1169,7 +1156,7 @@ class FormTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_filter_and_mutate_fields_request_values()
     {
         $toMutateValue = ' test ';
@@ -1184,7 +1171,7 @@ class FormTest extends FormBuilderTestCase
         $this->assertEquals('TEST', $this->request['test_field']);
     }
 
-    /** @test */
+    #[Test]
     public function it_add_option_attributes_properly()
     {
         $config = $this->config;

--- a/tests/RulesParserTest.php
+++ b/tests/RulesParserTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Kris\LaravelFormBuilder\Fields\InputType;
+use PHPUnit\Framework\Attributes\Test;
 
 class RulesParserTest extends FormBuilderTestCase
 {
@@ -16,7 +17,7 @@ class RulesParserTest extends FormBuilderTestCase
         $this->parser = $this->formHelper->createRulesParser($field);
     }
 
-    /** @test */
+    #[Test]
     public function it_parses_the_several_rules_from_string()
     {
         $validAttrs = [
@@ -29,7 +30,7 @@ class RulesParserTest extends FormBuilderTestCase
         $this->assertEquals($validAttrs , $this->parser->parse('required|min:5|alpha_num'));
     }
 
-    /** @test */
+    #[Test]
     public function it_parses_the_required_rule()
     {
         $this->assertEquals(
@@ -38,7 +39,7 @@ class RulesParserTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_parses_the_accepted_rule()
     {
         $this->assertEquals(
@@ -47,7 +48,7 @@ class RulesParserTest extends FormBuilderTestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_parses_the_alpha_rule()
     {
         $this->assertEquals(


### PR DESCRIPTION
Added support for laravel 13.
Dropped support for Laravel 10 & 11 as the minumum php version for 13 is not supported by these laravel versions.
Modernize tests and get rid of the deprecated addMethods method.